### PR TITLE
CreateUserUseCase: error not handled in try...catch statement

### DIFF
--- a/src/modules/users/useCases/createUser/CreateUserUseCase.ts
+++ b/src/modules/users/useCases/createUser/CreateUserUseCase.ts
@@ -51,19 +51,16 @@ export class CreateUserUseCase implements UseCase<CreateUserDTO, Promise<Respons
         ) as Response;
       }
 
-      try {
-        const alreadyCreatedUserByUserName = await this.userRepo
-        .getUserByUserName(username);
+      const alreadyCreatedUserByUserName = await this.userRepo
+      .getUserByUserName(username);
 
-        const userNameTaken = !!alreadyCreatedUserByUserName === true;
+      const userNameTaken = !!alreadyCreatedUserByUserName === true;
 
-        if (userNameTaken) {
-          return left (
-            new CreateUserErrors.UsernameTakenError(username.value)
-          ) as Response;
-        }
-      } catch (err) {}
-
+      if (userNameTaken) {
+        return left (
+          new CreateUserErrors.UsernameTakenError(username.value)
+        ) as Response;
+      }
 
       const userOrError: Result<User> = User.create({
         email, password, username,


### PR DESCRIPTION
This can cause a user with a username already taken to be created if something goes wrong with userRepo.getUserByUserName().

If something goes wrong with userRepo.getUserByUserName(), I guess it should be considered an app error which is already handled by the overlying try...catch statement.