### PR TITLE
Automate toolkit

### DIFF
--- a/automate/LocalState.json
+++ b/automate/LocalState.json
@@ -1,0 +1,5 @@
+{
+  "CurrentPattern": "Qps9Xgbd",
+  "CurrentToolkit": "Qps9Xgbd",
+  "CurrentDraft": "AGZBMCM6"
+}

--- a/automate/README.md
+++ b/automate/README.md
@@ -1,0 +1,288 @@
+# Step 1: Analyze the codebase for patterns
+
+Looking at the codebase, the file structure, and the files, it appears that we have the manifestation of 3 main top-level concepts:
+
+* A SubDomain (eg. `forum` and `users`)
+* A Resource (Aggregate or Entity) (eg. `post` `comment` `member`or `user`)
+* A UseCase (eg. `create...` or `getPopular...` or `upvote...`)
+
+Other observations of the pattern:
+
+* The concept of a "usecase" always has an associated API endpoint, which is either a GET (query) or a POST (command)
+* The concept of a "resource" can either be a root aggregate or an entity, and they are implemented differently.
+
+**Logical Relationships:**
+
+* A Subdomain can have one or more Resources (only 1 Aggregate but many Entity)
+* A Resource has one or more UseCases
+
+**Structure:**
+
+* A SubDomain
+  * Name (eg. `forum` and `users`) -- we will need to disambiguate singular/plural naming convention here. We shall default to singular.
+* A Resource
+  * Name (eg. `post` or `comment`)
+  * Kind = `aggregate` or `entity`
+* A UseCase
+  * Name (e.g. `create` or `getPopular`)
+  * Kind (e.g. `command` or `query`)
+
+# Step 2: Define the Pattern 
+
+
+
+## Pattern Structure
+
+The structure of the pattern is:
+
+```
+automate create pattern "SubDomain"
+automate edit add-attribute "Name" --isrequired
+
+automate edit add-collection "Resource" --isrequired --aschildof "{SubDomain}"
+automate edit add-attribute "Name" --isrequired --aschildof "{SubDomain.Resource}"
+automate edit add-attribute "Kind" --isrequired --isoneof "aggregate;entity" --defaultvalueis "entity" --aschildof "{SubDomain.Resource}"
+
+automate edit add-collection "UseCase" --isrequired --aschildof "{SubDomain.Resource}"
+automate edit add-attribute "Name" --isrequired --aschildof "{SubDomain.Resource.UseCase}"
+automate edit add-attribute "Kind" --isrequired --isoneof "command;query" --defaultvalueis "command" --aschildof "{SubDomain.Resource.UseCase}"
+automate edit add-attribute "Route" --isrequired --defaultvalueis "/" --aschildof "{SubDomain.Resource.UseCase}"
+automate edit add-attribute "IsAuthenticated" --isrequired --isoftype "bool" --defaultvalueis "true" --aschildof "{SubDomain.Resource.UseCase}"
+```
+
+> We are enforcing that a `SubDomain` cannot exist without at least one `Resource`.
+>
+> We are enforcing that a `Resource` cannot exist without at least one `UseCase` 
+>
+> We can't (this version of automate) enforce the implied constraint that there can only be one `Aggregate`, but one or more `Entities`.
+
+
+
+## Pattern Automation
+
+The code templates to harvest from the existing codebase are:
+
+On each `Resource`:
+
+```
+automate edit add-codetemplate-with-command "src/modules/forum/domain/post.ts" --name "Resource" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}.ts" --aschildof "{SubDomain.Resource}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/dtos/postDTO.ts" --name "DTO" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/dtos/{{Name | string.camelsingular}}DTO.ts" --aschildof "{SubDomain.Resource}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/infra/http/routes/post.ts" --name "Routes" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/infra/http/routes/{{Name | string.camelsingular}}.ts" --aschildof "{SubDomain.Resource}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/mappers/postMap.ts" --name "Mapper" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/mappers/{{Name | string.camelsingular}}Map.ts" --aschildof "{SubDomain.Resource}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/repos/postRepo.ts" --name "RepoInterface" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/repos/{{Name | string.camelsingular}}Repo.ts" --aschildof "{SubDomain.Resource}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/repos/implementations/sequelizePostRepo.ts" --name "RepoImplementation" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/repos/sequelize{{Name | string.camelsingular}}Repo.ts" --aschildof "{SubDomain.Resource}"
+
+automate edit add-codetemplate-with-command ".\src\modules\forum\repos\index.ts" --name "RepoIndex" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/repos/index.ts" --aschildof "{SubDomain.Resource}" 
+
+automate edit add-codetemplate-with-command ".\src\modules\forum\domain\postId.ts" --name "Identifier" --isoneoff --targetpath "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}Id.ts" --aschildof "{SubDomain.Resource}"
+```
+
+On each `UseCase`:
+
+```
+automate edit add-codetemplate-with-command "src/modules/forum/useCases/post/createPost/CreatePost.ts" --name "UseCase" --isoneoff --targetpath "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}.ts" --aschildof "{SubDomain.Resource.UseCase}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/useCases/post/createPost/CreatePostController.ts" --name "Controller" --isoneoff --targetpath "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}Controller.ts" --aschildof "{SubDomain.Resource.UseCase}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/useCases/post/createPost/CreatePostDTO.ts" --name "DTO" --isoneoff --targetpath "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}DTO.ts" --aschildof "{SubDomain.Resource.UseCase}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/useCases/post/createPost/CreatePostErrors.ts" --name "Errors" --isoneoff --targetpath "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}Errors.ts" --aschildof "{SubDomain.Resource.UseCase}"
+
+automate edit add-codetemplate-with-command "src/modules/forum/useCases/post/createPost/index.ts" --name "Index" --isoneoff --targetpath "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/index.ts" --aschildof "{SubDomain.Resource.UseCase}"
+```
+
+On whole pattern:
+
+```
+automate edit add-command-launchpoint "*" --name "Go" --from "{SubDomain.Resource}"
+automate edit update-command-launchpoint "Go" --add "*" --from "{SubDomain.Resource.UseCase}"
+```
+
+
+
+# Step 3: First look at the toolkit
+
+## Build the toolkit
+
+```
+automate build toolkit
+```
+
+## Install the toolkit
+
+```
+automate install toolkit "C:\Users\jezzs\OneDrive\Desktop\SubDomain_0.1.0.toolkit"
+```
+
+## Create a draft
+
+```
+automate run toolkit "SubDomain" --name "bananas"
+```
+
+## Configure the draft for a new sub domain, a new resource and a couple use cases
+
+```
+automate configure on "{SubDomain}" --and-set "Name=Bananas"
+automate configure add-one-to "{SubDomain.Resource}" --and-set "Name=Apple" --and-set "Kind=aggregate"
+automate configure add-one-to "{SubDomain.Resource.<RESOURCEID>.UseCase}" --and-set "Name=Create" --and-set "Kind=command" --and-set "Route=/"
+automate configure add-one-to "{SubDomain.Resource.<RESOURCEID>.UseCase}" --and-set "Name=Get" --and-set "Kind=query" --and-set "Route=/"
+```
+
+## Validate the draft
+
+```
+automate validate draft
+```
+
+## Apply the draft
+
+```
+automate execute command "Go"
+```
+
+This will generate a bunch of files and folders in the codebase for us to look at.
+
+
+
+# Step 4: Modify the Pattern
+
+## Review the structure 
+
+We may notice that some of the folders and filenames are not quite right, perhaps?
+
+We can now correct those files and folder names, by changing the `--targetpath` of the relevant code template command that generated them. 
+
+First, we need to know which command to edit. The answer is in this data:
+
+```
+automate view pattern --all
+```
+
+Find the automation that references the code template called `DTO`. 
+
+In this case, the command is called `CodeTemplateCommand2`, so that is the one we can change the `--targetpath` on.
+
+```
+automate edit update-codetemplate-with-command "CodeTemplateCommand2" --targetpath "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}.ts" --aschildof "{SubDomain.Resource.UseCase}"
+```
+
+ Once changed, you can test the command to see what path it will produce, using dummy test data.
+
+```
+automate test codetemplate-command "CodeTemplateCommand2" --aschildof "{SubDomain.Resource.UseCase}"
+```
+
+## Review the code templates
+
+Edit all the code templates:
+
+* Add relevant substitutions e.g. `{{Parent.Name | string.pascalsingular}}`
+* Add conditional and looping logic
+
+List templates to edit:
+
+```
+automate view pattern --all
+```
+
+Edit a specific template: 
+
+```
+automate edit codetemplate "DTO" --aschildof "{SubDomain.Resource}"  --with notepad.exe
+```
+
+You can test any of the code templates with dummy data:
+
+```
+automate test codetemplate "DTO" --aschildof "{SubDomain.Resource}" --export-data "sampleresource.json"
+```
+
+Then, edit the generated `sampleresource.json` file and add some other pieces of data.
+
+In our case, a use case for a `command` and use case for a `query`, and some variance for other things.
+
+ ```
+ {
+   "Id": "4JaUqrdF",
+   "Name": "name3",
+   "Kind": "entity",
+   "UseCase": {
+     "Id": "4vsrPzdy",
+     "Items": [
+       {
+         "Id": "cnHgDyzy",
+         "Name": "create",
+         "Kind": "command",
+         "Route": "/acreateroute",
+         "IsAuthenticated": true
+       },
+       {
+         "Id": "eYu3NeX3",
+         "Name": "get",
+         "Kind": "query",
+         "Route": "/agetroute",
+         "IsAuthenticated": true
+       },
+       {
+         "Id": "6rauJeDh",
+         "Name": "change",
+         "Kind": "command",
+         "Route": "/achangeroute",
+         "IsAuthenticated": false
+       }
+     ]
+   }
+ }
+ ```
+
+Now, we can use this more specific file to test with:
+
+```
+automate test codetemplate "DTO" --aschildof "{SubDomain.Resource}" --import-data "sampleresource.json"
+```
+
+## Rebuild, upgrade
+
+Once we have updated and tested the commands and code templates, it's time to upgrade the toolkit and try it out again.
+
+```
+automate build toolkit
+```
+
+This creates the next version of the toolkit, which we need to install.
+
+```
+automate install toolkit "C:\Users\jezzs\OneDrive\Desktop\SubDomain_0.2.0.toolkit"
+```
+
+Now, we need to upgrade our existing draft
+
+```
+automate upgrade draft
+```
+
+## Clear out old code
+
+Before we run the toolkit again, we need to delete the original code that it created.
+
+We need to do this because (at this point) most of the code template commands are configured only to generate `--isoneoff` templates. 
+
+In this configuration, those commands will not run if the generated already exists on disk (as is the case right now).
+
+First, delete all the newly generated code.
+
+## Try again
+
+With the old code gone, it is time to retry the toolkit.
+
+```
+automate execute command "Go"
+```
+
+Now, lets review, and refine the generated code, as above.

--- a/automate/drafts/AGZBMCM6/Draft.json
+++ b/automate/drafts/AGZBMCM6/Draft.json
@@ -1,0 +1,740 @@
+{
+  "Id": "AGZBMCM6",
+  "Name": "example",
+  "Toolkit": {
+    "Id": "Qps9Xgbd",
+    "Version": "0.4.0",
+    "RuntimeVersion": "0.2.3-preview",
+    "Pattern": {
+      "Id": "Qps9Xgbd",
+      "Name": "SubDomain",
+      "Attributes": [
+        {
+          "Id": "ppTa0ZPY",
+          "Name": "Name",
+          "DataType": "string",
+          "IsRequired": true,
+          "Choices": []
+        }
+      ],
+      "Elements": [
+        {
+          "Id": "YQY1UP9X",
+          "Name": "Resource",
+          "Attributes": [
+            {
+              "Id": "nYEcsBJ0",
+              "Name": "Name",
+              "DataType": "string",
+              "IsRequired": true,
+              "Choices": []
+            },
+            {
+              "Id": "zyMKwj1w",
+              "Name": "Kind",
+              "DataType": "string",
+              "IsRequired": true,
+              "DefaultValue": "entity",
+              "Choices": [
+                "aggregate",
+                "entity"
+              ]
+            }
+          ],
+          "Elements": [
+            {
+              "Id": "fG9N9vM6",
+              "Name": "UseCase",
+              "Attributes": [
+                {
+                  "Id": "gTRJAA6u",
+                  "Name": "Name",
+                  "DataType": "string",
+                  "IsRequired": true,
+                  "Choices": []
+                },
+                {
+                  "Id": "24hWYBWf",
+                  "Name": "Kind",
+                  "DataType": "string",
+                  "IsRequired": true,
+                  "DefaultValue": "command",
+                  "Choices": [
+                    "command",
+                    "query"
+                  ]
+                },
+                {
+                  "Id": "znJ67wqj",
+                  "Name": "Route",
+                  "DataType": "string",
+                  "IsRequired": true,
+                  "DefaultValue": "/",
+                  "Choices": []
+                },
+                {
+                  "Id": "x3H8M06Q",
+                  "Name": "IsAuthenticated",
+                  "DataType": "bool",
+                  "IsRequired": true,
+                  "DefaultValue": "true",
+                  "Choices": []
+                }
+              ],
+              "CodeTemplates": [
+                {
+                  "Id": "dwDXxv9G",
+                  "Name": "UseCase",
+                  "LastModifiedUtc": "2022-06-13T08:57:11.8172269Z",
+                  "Metadata": {
+                    "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePost.ts",
+                    "OriginalFileExtension": ".ts"
+                  }
+                },
+                {
+                  "Id": "PmEpX6M7",
+                  "Name": "Controller",
+                  "LastModifiedUtc": "2022-06-13T08:54:14.9353515Z",
+                  "Metadata": {
+                    "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostController.ts",
+                    "OriginalFileExtension": ".ts"
+                  }
+                },
+                {
+                  "Id": "1uxps3Sc",
+                  "Name": "DTO",
+                  "LastModifiedUtc": "2022-06-13T08:50:57.6134271Z",
+                  "Metadata": {
+                    "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostDTO.ts",
+                    "OriginalFileExtension": ".ts"
+                  }
+                },
+                {
+                  "Id": "cd8R6rKQ",
+                  "Name": "Errors",
+                  "LastModifiedUtc": "2022-06-13T08:46:12.6939558Z",
+                  "Metadata": {
+                    "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostErrors.ts",
+                    "OriginalFileExtension": ".ts"
+                  }
+                },
+                {
+                  "Id": "Dn8BrSRK",
+                  "Name": "Index",
+                  "LastModifiedUtc": "2022-06-13T08:41:16.3553577Z",
+                  "Metadata": {
+                    "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\index.ts",
+                    "OriginalFileExtension": ".ts"
+                  }
+                }
+              ],
+              "Automation": [
+                {
+                  "Id": "VUbQMgMU",
+                  "Name": "UseCaseCommand1",
+                  "Type": "CodeTemplateCommand",
+                  "Metadata": {
+                    "CodeTemplateId": "dwDXxv9G",
+                    "IsOneOff": true,
+                    "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}.ts"
+                  }
+                },
+                {
+                  "Id": "V3CskeRB",
+                  "Name": "ControllerCommand2",
+                  "Type": "CodeTemplateCommand",
+                  "Metadata": {
+                    "CodeTemplateId": "PmEpX6M7",
+                    "IsOneOff": true,
+                    "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller.ts"
+                  }
+                },
+                {
+                  "Id": "rmWtB8Mg",
+                  "Name": "DTOCommand3",
+                  "Type": "CodeTemplateCommand",
+                  "Metadata": {
+                    "CodeTemplateId": "1uxps3Sc",
+                    "IsOneOff": true,
+                    "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO.ts"
+                  }
+                },
+                {
+                  "Id": "5M93B0Sd",
+                  "Name": "ErrorsCommand4",
+                  "Type": "CodeTemplateCommand",
+                  "Metadata": {
+                    "CodeTemplateId": "cd8R6rKQ",
+                    "IsOneOff": true,
+                    "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Errors.ts"
+                  }
+                },
+                {
+                  "Id": "KcSe1axf",
+                  "Name": "IndexCommand5",
+                  "Type": "CodeTemplateCommand",
+                  "Metadata": {
+                    "CodeTemplateId": "Dn8BrSRK",
+                    "IsOneOff": true,
+                    "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/index.ts"
+                  }
+                },
+                {
+                  "Id": "8HYpvvQc",
+                  "Name": "Go",
+                  "Type": "CommandLaunchPoint",
+                  "Metadata": {
+                    "CommandIds": "VUbQMgMU;V3CskeRB;rmWtB8Mg;5M93B0Sd;KcSe1axf"
+                  }
+                }
+              ],
+              "IsCollection": true,
+              "Cardinality": "OneOrMany",
+              "AutoCreate": true
+            }
+          ],
+          "CodeTemplates": [
+            {
+              "Id": "7R1gAwGe",
+              "Name": "Resource",
+              "LastModifiedUtc": "2022-06-13T09:43:10.7913419Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\domain\\post.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "ne5ds8AR",
+              "Name": "DTO",
+              "LastModifiedUtc": "2022-06-12T20:18:16.7838134Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\dtos\\postDTO.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "VdsjeCF0",
+              "Name": "Routes",
+              "LastModifiedUtc": "2022-06-13T09:17:34.8980803Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\infra\\http\\routes\\post.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "r4VRhFkE",
+              "Name": "Mapper",
+              "LastModifiedUtc": "2022-06-13T09:14:55.5337241Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\mappers\\postMap.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "cTfY562u",
+              "Name": "RepoInterface",
+              "LastModifiedUtc": "2022-06-13T08:58:55.9112055Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\postRepo.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "2CcBpTbV",
+              "Name": "RepoImplementation",
+              "LastModifiedUtc": "2022-06-12T20:42:25.5150081Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\implementations\\sequelizePostRepo.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "yZY2WRg8",
+              "Name": "Identifier",
+              "LastModifiedUtc": "2022-06-13T08:29:40.5508653Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\domain\\postId.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "r5vt6KT5",
+              "Name": "RepoIndex",
+              "LastModifiedUtc": "2022-06-13T09:12:39.2209728Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\index.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            }
+          ],
+          "Automation": [
+            {
+              "Id": "Gb3r11qG",
+              "Name": "ResourceCommand1",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "7R1gAwGe",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}.ts"
+              }
+            },
+            {
+              "Id": "XxMmzS0H",
+              "Name": "DTOCommand2",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "ne5ds8AR",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/dtos/{{Name | string.camelsingular}}DTO.ts"
+              }
+            },
+            {
+              "Id": "x664EbyV",
+              "Name": "RoutesCommand3",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "VdsjeCF0",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/infra/http/routes/{{Name | string.camelsingular}}.ts"
+              }
+            },
+            {
+              "Id": "eZYU0UWX",
+              "Name": "MapperCommand5",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "r4VRhFkE",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/mappers/{{Name | string.camelsingular}}Map.ts"
+              }
+            },
+            {
+              "Id": "VsEhhtp3",
+              "Name": "RepoInterfaceCommand4",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "cTfY562u",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/{{Name | string.camelsingular}}Repo.ts"
+              }
+            },
+            {
+              "Id": "f4m3qHck",
+              "Name": "RepoImplementationCommand6",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "2CcBpTbV",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/implementations/sequelize{{Name | string.pascalsingular}}Repo.ts"
+              }
+            },
+            {
+              "Id": "75jm5Xj0",
+              "Name": "IdentifierCommand7",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "yZY2WRg8",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}Id.ts"
+              }
+            },
+            {
+              "Id": "SaPEKz6h",
+              "Name": "RepoIndexCommand8",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "r5vt6KT5",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/index.ts"
+              }
+            }
+          ],
+          "IsCollection": true,
+          "Cardinality": "OneOrMany",
+          "AutoCreate": true
+        }
+      ],
+      "Automation": [
+        {
+          "Id": "5DhrMHhf",
+          "Name": "Go",
+          "Type": "CommandLaunchPoint",
+          "Metadata": {
+            "CommandIds": "Gb3r11qG;XxMmzS0H;x664EbyV;eZYU0UWX;VsEhhtp3;f4m3qHck;75jm5Xj0;SaPEKz6h;VUbQMgMU;V3CskeRB;rmWtB8Mg;5M93B0Sd;KcSe1axf"
+          }
+        }
+      ],
+      "DisplayName": "SubDomain",
+      "ToolkitVersion": {
+        "Current": "0.4.0",
+        "LastChanges": "NoChange"
+      }
+    },
+    "CodeTemplateFiles": [
+      {
+        "Id": "7R1gAwGe",
+        "Contents": "DQppbXBvcnQgeyBBZ2dyZWdhdGVSb290IH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2RvbWFpbi9BZ2dyZWdhdGVSb290IjsNCmltcG9ydCB7IEVudGl0eSB9IGZyb20gIi4uLy4uLy4uL3NoYXJlZC9kb21haW4vRW50aXR5IjsNCmltcG9ydCB7IFVuaXF1ZUVudGl0eUlEIH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2RvbWFpbi9VbmlxdWVFbnRpdHlJRCI7DQppbXBvcnQgeyBSZXN1bHQsIEVpdGhlciwgbGVmdCwgcmlnaHQgfSBmcm9tICIuLi8uLi8uLi9zaGFyZWQvY29yZS9SZXN1bHQiOw0KaW1wb3J0IHsgR3VhcmQsIElHdWFyZEFyZ3VtZW50IH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2NvcmUvR3VhcmQiOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCB9IGZyb20gIi4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkIjsNCg0KZXhwb3J0IGludGVyZmFjZSB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVByb3BzIHsNCiAgLy9UT0RPOiBhZGQgZG9tYWluIHByb3BlcnRpZXMNCn0NCg0Ke3t\u002BaWYgKEtpbmQ9PSJhZ2dyZWdhdGUiKX59fQ0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19IGV4dGVuZHMgQWdncmVnYXRlUm9vdDx7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVByb3BzPiB7DQp7e35lbHNlfn19DQpleHBvcnQgY2xhc3Mge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gZXh0ZW5kcyBFbnRpdHk8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Qcm9wcz4gew0Ke3t\u002BZW5kfn19DQoNCiAgZ2V0IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1JZCAoKToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCB7DQogICAgcmV0dXJuIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQuY3JlYXRlKHRoaXMuX2lkKQ0KICAgIC5nZXRWYWx1ZSgpOw0KICB9DQoNCiAgLy9UT0RPOiBhZGQgZG9tYWluIHByb3BlcnRpZXMNCg0KICBwcml2YXRlIGNvbnN0cnVjdG9yIChwcm9wczoge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Qcm9wcywgaWQ/OiBVbmlxdWVFbnRpdHlJRCkgew0KICAgIHN1cGVyKHByb3BzLCBpZCk7DQogIH0NCg0KICBwdWJsaWMgc3RhdGljIGNyZWF0ZSAocHJvcHM6IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UHJvcHMsIGlkPzogVW5pcXVlRW50aXR5SUQpOiBSZXN1bHQ8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0\u002BIHsNCiAgICBjb25zdCBndWFyZEFyZ3M6IElHdWFyZEFyZ3VtZW50W10gPSBbDQogICAgXTsNCg0KICAgIC8vVE9ETzogYWRkIGFyZ3VtZW50cyB0byBndWFyZA0KDQogICAgY29uc3QgZ3VhcmRSZXN1bHQgPSBHdWFyZC5hZ2FpbnN0TnVsbE9yVW5kZWZpbmVkQnVsayhndWFyZEFyZ3MpOw0KDQogICAgaWYgKGd1YXJkUmVzdWx0LmlzRmFpbHVyZSkgew0KICAgICAgcmV0dXJuIFJlc3VsdC5mYWlsPHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19PihndWFyZFJlc3VsdC5nZXRFcnJvclZhbHVlKCkpOw0KICAgIH0NCg0KICAgIGNvbnN0IGRlZmF1bHRWYWx1ZXM6IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UHJvcHMgPSB7DQogICAgICAuLi5wcm9wcw0KICAgICAgLy9UT0RPOiBvdGhlciBwcm9wZXJ0aWVzDQogICAgfTsNCg0KICAgIGNvbnN0IGlzTmV3e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gPSAhIWlkID09PSBmYWxzZTsNCiAgICBjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19ID0gbmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19KGRlZmF1bHRWYWx1ZXMsIGlkKTsNCg0KICAgIGlmIChpc05ld3t7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19KSB7DQogICAgICAvL1RPRE86IGRvIGluaXRpYWxpemF0aW9ucw0KICAgICAgLy9UT0RPOiBjcmVhdGUgZG9tYWluIGV2ZW50DQogICAgICAvL3t7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0uYWRkRG9tYWluRXZlbnQobmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q3JlYXRlZCh7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19KSk7DQoNCiAgICB9DQoNCiAgICByZXR1cm4gUmVzdWx0Lm9rPHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Pih7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19KTsNCiAgfQ0KfQ=="
+      },
+      {
+        "Id": "ne5ds8AR",
+        "Contents": "DQoNCmV4cG9ydCBpbnRlcmZhY2Uge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1EVE8gew0KICAvL1RPRE86IGFkZCB5b3VyIHByb3BlcnRpZXMNCn0NCg0K"
+      },
+      {
+        "Id": "VdsjeCF0",
+        "Contents": "DQppbXBvcnQgZXhwcmVzcyBmcm9tICdleHByZXNzJzsNCmltcG9ydCB7IG1pZGRsZXdhcmUgfSBmcm9tICcuLi8uLi8uLi8uLi8uLi9zaGFyZWQvaW5mcmEvaHR0cCc7DQp7e35mb3IgdXNlY2FzZSBpbiBVc2VDYXNlLkl0ZW1zfn19DQppbXBvcnQgeyB7e3VzZWNhc2UuTmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX17e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUNvbnRyb2xsZXIgfSBmcm9tICcuLi8uLi8uLi91c2VDYXNlcy97e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19L3t7dXNlY2FzZS5OYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19JzsNCnt7fmVuZH59fQ0KDQpjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19Um91dGVyID0gZXhwcmVzcy5Sb3V0ZXIoKTsNCg0Ke3t\u002BZm9yIHVzZWNhc2UgaW4gVXNlQ2FzZS5JdGVtc359fQ0Ke3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJvdXRlci57e2lmICh1c2VjYXNlLktpbmQ9PSJjb21tYW5kIil9fXBvc3R7e2Vsc2V9fWdldHt7ZW5kfX0oJ3t7dXNlY2FzZS5Sb3V0ZX19JywNCiAge3tpZiAodXNlY2FzZS5Jc0F1dGhlbnRpY2F0ZWQpfX1taWRkbGV3YXJlLmVuc3VyZUF1dGhlbnRpY2F0ZWQoKSx7e2VuZH19DQogIChyZXEsIHJlcykgPT4ge3t1c2VjYXNlLk5hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Db250cm9sbGVyLmV4ZWN1dGUocmVxLCByZXMpDQopDQp7e35lbmR\u002BfX0NCg0KZXhwb3J0IHsNCiAge3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJvdXRlcg0KfQ0KDQo="
+      },
+      {
+        "Id": "r4VRhFkE",
+        "Contents": "DQppbXBvcnQgeyBNYXBwZXIgfSBmcm9tICIuLi8uLi8uLi9zaGFyZWQvaW5mcmEvTWFwcGVyIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19IH0gZnJvbSAiLi4vZG9tYWluL3t7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0iOw0KaW1wb3J0IHsgVW5pcXVlRW50aXR5SUQgfSBmcm9tICIuLi8uLi8uLi9zaGFyZWQvZG9tYWluL1VuaXF1ZUVudGl0eUlEIjsNCg0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19TWFwIGltcGxlbWVudHMgTWFwcGVyPHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19PiB7DQoNCiAgcHVibGljIHN0YXRpYyB0b0RvbWFpbiAocmF3OiBhbnkpOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB7DQogICAgDQogICAgY29uc3Qge3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IgPSB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fS5jcmVhdGUoew0KICAgICAgLy9UT0RPOiBtYXAgcHJvcGVydGllcyB0byBkb21haW4NCiAgICB9LCBuZXcgVW5pcXVlRW50aXR5SUQocmF3Lnt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1faWQpKQ0KDQogICAge3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IuaXNGYWlsdXJlID8gY29uc29sZS5sb2coe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IuZ2V0RXJyb3JWYWx1ZSgpKSA6ICcnOw0KDQogICAgcmV0dXJuIHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1PckVycm9yLmlzU3VjY2VzcyA/IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1PckVycm9yLmdldFZhbHVlKCkgOiBudWxsOw0KICB9DQoNCiAgcHVibGljIHN0YXRpYyB0b1BlcnNpc3RlbmNlICh7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19OiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSk6IGFueSB7DQogICAgcmV0dXJuIHsNCiAgICAgIC8vVE9ETzogbWFwIHByb3BlcnRpZXMgdG8gcGVyc2lzdA0KICAgICAgdXBkYXRlZEF0OiBuZXcgRGF0ZSgpLnRvU3RyaW5nKCksDQogICAgICB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19X2lkOiB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19Lnt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1JZC5pZC50b1N0cmluZygpLA0KICAgIH0NCiAgfQ0KfQ=="
+      },
+      {
+        "Id": "cTfY562u",
+        "Contents": "DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB9IGZyb20gIi4uL2RvbWFpbi97e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19IjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQgfSBmcm9tICIuLi9kb21haW4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkIjsNCg0KZXhwb3J0IGludGVyZmFjZSBJe3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvIHsNCiAgLy9UT0RPOiBhZGQgcmVwb3NpdG9yeSBtZXRob2RzDQogIGV4aXN0cyAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUlkKTogUHJvbWlzZTxib29sZWFuPjsNCiAgc2F2ZSAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0pOiBQcm9taXNlPHZvaWQ\u002BOw0KICBkZWxldGUgKHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1JZDoge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCk6IFByb21pc2U8dm9pZD47DQp9"
+      },
+      {
+        "Id": "2CcBpTbV",
+        "Contents": "DQppbXBvcnQgeyBJe3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvIH0gZnJvbSAiLi4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJlcG8iOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCB9IGZyb20gIi4uLy4uL2RvbWFpbi97e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQiOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gfSBmcm9tICIuLi8uLi9kb21haW4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fSI7DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1hcCB9IGZyb20gIi4uLy4uL21hcHBlcnMve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU1hcCI7DQoNCmV4cG9ydCBjbGFzcyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVJlcG8gaW1wbGVtZW50cyBJe3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvIHsNCg0KICBwcml2YXRlIG1vZGVsczogYW55Ow0KDQogIGNvbnN0cnVjdG9yIChtb2RlbHM6IGFueSkgew0KICAgIHRoaXMubW9kZWxzID0gbW9kZWxzOw0KICB9DQoNCiAgcHJpdmF0ZSBjcmVhdGVCYXNlUXVlcnkgKCk6IGFueSB7DQogICAgY29uc3QgbW9kZWxzID0gdGhpcy5tb2RlbHM7DQogICAgcmV0dXJuIHsNCiAgICAgIHdoZXJlOiB7fSwNCiAgICAgIGluY2x1ZGU6IFtdDQogICAgfQ0KICB9DQoNCiAgcHVibGljIGFzeW5jIGV4aXN0cyAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUlkKTogUHJvbWlzZTxib29sZWFuPiB7DQogICAgY29uc3Qge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Nb2RlbCA9IHRoaXMubW9kZWxzLnt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Ow0KICAgIGNvbnN0IGJhc2VRdWVyeSA9IHRoaXMuY3JlYXRlQmFzZVF1ZXJ5KCk7DQogICAgYmFzZVF1ZXJ5LndoZXJlWyd7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19X2lkJ10gPSB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQuaWQudG9TdHJpbmcoKTsNCiAgICBjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19ID0gYXdhaXQge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Nb2RlbC5maW5kT25lKGJhc2VRdWVyeSk7DQogICAgY29uc3QgZm91bmQgPSAhIXt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0gPT09IHRydWU7DQogICAgcmV0dXJuIGZvdW5kOw0KICB9DQoNCiAgcHVibGljIGRlbGV0ZSAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUlkKTogUHJvbWlzZTx2b2lkPiB7DQogICAgY29uc3Qge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Nb2RlbCA9IHRoaXMubW9kZWxzLnt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Ow0KICAgIHJldHVybiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1vZGVsLmRlc3Ryb3koeyB3aGVyZTogeyB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19X2lkOiB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQuaWQudG9TdHJpbmcoKSB9fSk7DQogIH0NCg0KICBwdWJsaWMgYXN5bmMgc2F2ZSAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0pOiBQcm9taXNlPHZvaWQ\u002BIHsNCiAgICBjb25zdCB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1vZGVsID0gdGhpcy5tb2RlbHMue3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX07DQogICAgY29uc3QgZXhpc3RzID0gYXdhaXQgdGhpcy5leGlzdHMoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fS57e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQpOw0KICAgIGNvbnN0IGlzTmV3e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gPSAhZXhpc3RzOw0KICAgIGNvbnN0IHJhd1NlcXVlbGl6ZXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19ID0gYXdhaXQge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1NYXAudG9QZXJzaXN0ZW5jZSh7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19KTsNCiAgICANCiAgICBpZiAoaXNOZXd7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSkgew0KDQogICAgICB0cnkgew0KICAgICAgICBhd2FpdCB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1vZGVsLmNyZWF0ZShyYXdTZXF1ZWxpemV7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSk7DQogICAgICAgIA0KICAgICAgfSBjYXRjaCAoZXJyKSB7DQogICAgICAgIGF3YWl0IHRoaXMuZGVsZXRlKHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0ue3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkKTsNCiAgICAgICAgdGhyb3cgbmV3IEVycm9yKGVyci50b1N0cmluZygpKQ0KICAgICAgfQ0KDQogICAgfSBlbHNlIHsNCiAgICAgIGF3YWl0IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19TW9kZWwudXBkYXRlKHJhd1NlcXVlbGl6ZXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19LCB7IA0KICAgICAgICAvLyBUbyBtYWtlIHN1cmUgeW91ciBob29rcyBhbHdheXMgcnVuLCBtYWtlIHN1cmUgdG8gaW5jbHVkZSB0aGlzIGluDQogICAgICAgIC8vIHRoZSBxdWVyeQ0KICAgICAgICBpbmRpdmlkdWFsSG9va3M6IHRydWUsICANCiAgICAgICAgaG9va3M6IHRydWUsDQogICAgICAgIHdoZXJlOiB7IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1faWQ6IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0ue3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkLmlkLnRvU3RyaW5nKCkgfQ0KICAgICAgfSk7DQogICAgfQ0KICB9DQp9"
+      },
+      {
+        "Id": "dwDXxv9G",
+        "Contents": "DQppbXBvcnQgeyBVc2VDYXNlIH0gZnJvbSAiLi4vLi4vLi4vLi4vLi4vc2hhcmVkL2NvcmUvVXNlQ2FzZSI7IA0KaW1wb3J0IHsgSXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyB9IGZyb20gIi4uLy4uLy4uL3JlcG9zL3t7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvIjsNCmltcG9ydCB7IEVpdGhlciwgUmVzdWx0LCBsZWZ0LCByaWdodCB9IGZyb20gIi4uLy4uLy4uLy4uLy4uL3NoYXJlZC9jb3JlL1Jlc3VsdCI7DQppbXBvcnQgeyBBcHBFcnJvciB9IGZyb20gIi4uLy4uLy4uLy4uLy4uL3NoYXJlZC9jb3JlL0FwcEVycm9yIjsNCmltcG9ydCB7IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19LCB7e1BhcmVudC5OYW1lIHxzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVByb3BzIH0gZnJvbSAiLi4vLi4vLi4vZG9tYWluL3t7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX0iOw0KDQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIH0gZnJvbSAiLi97e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1FcnJvcnMgfSBmcm9tICIuL3t7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1FcnJvcnMiOw0KDQp0eXBlIFJlc3BvbnNlID0gRWl0aGVyPA0KICBBcHBFcnJvci5VbmV4cGVjdGVkRXJyb3IgfA0KICBSZXN1bHQ8YW55PiwNCiAgUmVzdWx0PHZvaWQ\u002BDQo\u002BDQoNCmV4cG9ydCBjbGFzcyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19IGltcGxlbWVudHMgVXNlQ2FzZTx7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPLCBQcm9taXNlPFJlc3BvbnNlPj4gew0KICBwcml2YXRlIHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvOiBJe3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvOw0KDQogIGNvbnN0cnVjdG9yICh7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbzogSXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbykgew0KICAgIHRoaXMue3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJlcG8gPSB7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbzsNCiAgfQ0KICANCiAgcHVibGljIGFzeW5jIGV4ZWN1dGUgKHJlcXVlc3Q6IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1EVE8pOiBQcm9taXNlPFJlc3BvbnNlPiB7DQogICAgbGV0IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX06IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Ow0KDQogICAgdHJ5IHsNCg0KICAgICAgLy9UT0RPOiBjb25zdHJ1Y3QgeW91ciBzdGF0ZQ0KDQogICAgICBjb25zdCB7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19UHJvcHM6IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UHJvcHMgPSB7DQogICAgICAgIC8vVE9ETzogaW5pdGlhbGl6ZSB5b3VyIHByb3BlcnRpZXMNCiAgICAgIH0NCg0KICAgICAgY29uc3Qge3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IgPSB7e1BhcmVudC5OYW1lIHxzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fS5jcmVhdGUoe3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVByb3BzKTsNCg0KICAgICAgaWYgKHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1PckVycm9yLmlzRmFpbHVyZSkgew0KICAgICAgICByZXR1cm4gbGVmdCh7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19T3JFcnJvcik7DQogICAgICB9DQoNCiAgICAgIHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX0gPSB7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19T3JFcnJvci5nZXRWYWx1ZSgpOw0KDQogICAgICBhd2FpdCB0aGlzLnt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvLnNhdmUoe3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fSk7DQoNCiAgICAgIHJldHVybiByaWdodChSZXN1bHQub2s8dm9pZD4oKSkNCg0KICAgIH0gY2F0Y2ggKGVycikgew0KICAgICAgcmV0dXJuIGxlZnQobmV3IEFwcEVycm9yLlVuZXhwZWN0ZWRFcnJvcihlcnIpKTsNCiAgICB9DQogIH0NCn0="
+      },
+      {
+        "Id": "PmEpX6M7",
+        "Contents": "aW1wb3J0IHsgQmFzZUNvbnRyb2xsZXIgfSBmcm9tICIuLi8uLi8uLi8uLi8uLi9zaGFyZWQvaW5mcmEvaHR0cC9tb2RlbHMvQmFzZUNvbnRyb2xsZXIiOw0KaW1wb3J0IHsgRGVjb2RlZEV4cHJlc3NSZXF1ZXN0IH0gZnJvbSAiLi4vLi4vLi4vLi4vdXNlcnMvaW5mcmEvaHR0cC9tb2RlbHMvZGVjb2RlZFJlcXVlc3QiOw0KaW1wb3J0IHsgVGV4dFV0aWxzIH0gZnJvbSAiLi4vLi4vLi4vLi4vLi4vc2hhcmVkL3V0aWxzL1RleHRVdGlscyI7DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB9IGZyb20gIi4ve3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0iOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1EVE8gfSBmcm9tICIuL3t7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RXJyb3JzIH0gZnJvbSAiLi97e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUVycm9ycyI7DQoNCg0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q29udHJvbGxlciBleHRlbmRzIEJhc2VDb250cm9sbGVyIHsNCiAgcHJpdmF0ZSB1c2VDYXNlOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fTsNCg0KICBjb25zdHJ1Y3RvciAodXNlQ2FzZToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0pIHsNCiAgICBzdXBlcigpOw0KICAgIHRoaXMudXNlQ2FzZSA9IHVzZUNhc2U7DQogIH0NCg0KICBhc3luYyBleGVjdXRlSW1wbCAocmVxOiBEZWNvZGVkRXhwcmVzc1JlcXVlc3QsIHJlczogYW55KTogUHJvbWlzZTxhbnk\u002BIHsNCiAgICBjb25zdCB7IHVzZXJJZCB9ID0gcmVxLmRlY29kZWQ7DQoNCiAgICBjb25zdCBkdG86IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPID0gew0KICAgICAgLy9UT0RPOiBwb3B1bGF0ZSBwcm9wZXJ0aWVzDQogICAgfQ0KICANCiAgICB0cnkgew0KICAgICAgY29uc3QgcmVzdWx0ID0gYXdhaXQgdGhpcy51c2VDYXNlLmV4ZWN1dGUoZHRvKTsNCg0KICAgICAgaWYgKHJlc3VsdC5pc0xlZnQoKSkgew0KICAgICAgICBjb25zdCBlcnJvciA9IHJlc3VsdC52YWx1ZTsNCiAgDQogICAgICAgIHN3aXRjaCAoZXJyb3IuY29uc3RydWN0b3IpIHsNCiAgICAgICAgICBkZWZhdWx0Og0KICAgICAgICAgICAgcmV0dXJuIHRoaXMuZmFpbChyZXMsIGVycm9yLmdldEVycm9yVmFsdWUoKS5tZXNzYWdlKTsNCiAgICAgICAgfQ0KICAgICAgICANCiAgICAgIH0gZWxzZSB7DQogICAgICAgIHJldHVybiB0aGlzLm9rKHJlcyk7DQogICAgICB9DQoNCiAgICB9IGNhdGNoIChlcnIpIHsNCiAgICAgIHJldHVybiB0aGlzLmZhaWwocmVzLCBlcnIpDQogICAgfQ0KICB9DQp9"
+      },
+      {
+        "Id": "1uxps3Sc",
+        "Contents": "DQpleHBvcnQgaW50ZXJmYWNlIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIHsNCiAgLy9UT0RPOiBwcm9wZXJ0aWVzDQp9"
+      },
+      {
+        "Id": "cd8R6rKQ",
+        "Contents": "DQppbXBvcnQgeyBVc2VDYXNlRXJyb3IgfSBmcm9tICIuLi8uLi8uLi8uLi8uLi9zaGFyZWQvY29yZS9Vc2VDYXNlRXJyb3IiOw0KaW1wb3J0IHsgUmVzdWx0IH0gZnJvbSAiLi4vLi4vLi4vLi4vLi4vc2hhcmVkL2NvcmUvUmVzdWx0IjsNCg0KZXhwb3J0IG5hbWVzcGFjZSB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUVycm9ycyB7DQoNCiAgLy9UT0RPOiBhZGQgeW91ciBlcnJvcnMNCn0="
+      },
+      {
+        "Id": "Dn8BrSRK",
+        "Contents": "DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB9IGZyb20gIi4ve3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0iOw0KaW1wb3J0IHsge3tQYXJlbnQuTmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvIH0gZnJvbSAiLi4vLi4vLi4vcmVwb3MiOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Db250cm9sbGVyIH0gZnJvbSAiLi97e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUNvbnRyb2xsZXIiOw0KDQpjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19ID0gbmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19KHt7UGFyZW50Lk5hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbyk7DQpjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q29udHJvbGxlciA9IG5ldyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUNvbnRyb2xsZXIoDQogIHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0NCik7DQoNCmV4cG9ydCB7IA0KICB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19LA0KICB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q29udHJvbGxlcg0KfQ0KDQo="
+      },
+      {
+        "Id": "yZY2WRg8",
+        "Contents": "DQppbXBvcnQgeyBVbmlxdWVFbnRpdHlJRCB9IGZyb20gIi4uLy4uLy4uL3NoYXJlZC9kb21haW4vVW5pcXVlRW50aXR5SUQiOw0KaW1wb3J0IHsgUmVzdWx0IH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2NvcmUvUmVzdWx0IjsNCmltcG9ydCB7IEVudGl0eSB9IGZyb20gIi4uLy4uLy4uL3NoYXJlZC9kb21haW4vRW50aXR5IjsNCg0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQgZXh0ZW5kcyBFbnRpdHk8YW55PiB7DQoNCiAgZ2V0IGlkICgpOiBVbmlxdWVFbnRpdHlJRCB7DQogICAgcmV0dXJuIHRoaXMuX2lkOw0KICB9DQoNCiAgcHJpdmF0ZSBjb25zdHJ1Y3RvciAoaWQ/OiBVbmlxdWVFbnRpdHlJRCkgew0KICAgIHN1cGVyKG51bGwsIGlkKQ0KICB9DQoNCiAgcHVibGljIHN0YXRpYyBjcmVhdGUgKGlkPzogVW5pcXVlRW50aXR5SUQpOiBSZXN1bHQ8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZD4gew0KICAgIHJldHVybiBSZXN1bHQub2s8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZD4obmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQoaWQpKTsNCiAgfQ0KfQ=="
+      },
+      {
+        "Id": "r5vt6KT5",
+        "Contents": "DQppbXBvcnQgbW9kZWxzIGZyb20gIi4uLy4uLy4uL3NoYXJlZC9pbmZyYS9kYXRhYmFzZS9zZXF1ZWxpemUvbW9kZWxzIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyB9IGZyb20gIi4vaW1wbGVtZW50YXRpb25zL3NlcXVlbGl6ZXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyI7DQoNCmNvbnN0IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvID0gbmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyhtb2RlbHMpOw0KDQpleHBvcnQgeyB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbyB9Ow0K"
+      }
+    ]
+  },
+  "Model": {
+    "Id": "EXM8fcCm",
+    "Name": "SubDomain",
+    "Schema": {
+      "SchemaId": "Qps9Xgbd",
+      "SchemaType": "Pattern"
+    },
+    "Properties": {
+      "Name": {
+        "Id": "E25CX0X7",
+        "Name": "Name",
+        "Schema": {
+          "SchemaId": "ppTa0ZPY",
+          "SchemaType": "Attribute"
+        },
+        "Value": "ADomain",
+        "IsMaterialised": false
+      },
+      "Resource": {
+        "Id": "EebTtQDT",
+        "Name": "Resource",
+        "Schema": {
+          "SchemaId": "YQY1UP9X",
+          "SchemaType": "EphemeralCollection"
+        },
+        "Items": [
+          {
+            "Id": "N79CgPEB",
+            "Name": "Resource",
+            "Schema": {
+              "SchemaId": "YQY1UP9X",
+              "SchemaType": "CollectionItem"
+            },
+            "Properties": {
+              "Name": {
+                "Id": "bDgddMcM",
+                "Name": "Name",
+                "Schema": {
+                  "SchemaId": "nYEcsBJ0",
+                  "SchemaType": "Attribute"
+                },
+                "Value": "AnAggregate1",
+                "IsMaterialised": false
+              },
+              "Kind": {
+                "Id": "nnHd7P9H",
+                "Name": "Kind",
+                "Schema": {
+                  "SchemaId": "zyMKwj1w",
+                  "SchemaType": "Attribute"
+                },
+                "Value": "aggregate",
+                "IsMaterialised": true
+              },
+              "UseCase": {
+                "Id": "MdShVzd3",
+                "Name": "UseCase",
+                "Schema": {
+                  "SchemaId": "fG9N9vM6",
+                  "SchemaType": "EphemeralCollection"
+                },
+                "Properties": {
+                  "Route": {
+                    "Id": "B6dKzsea",
+                    "Name": "Route",
+                    "Schema": {
+                      "SchemaId": "znJ67wqj",
+                      "SchemaType": "Attribute"
+                    },
+                    "Value": "/",
+                    "IsMaterialised": true
+                  },
+                  "IsAuthenticated": {
+                    "Id": "ERGyjPaw",
+                    "Name": "IsAuthenticated",
+                    "Schema": {
+                      "SchemaId": "x3H8M06Q",
+                      "SchemaType": "Attribute"
+                    },
+                    "Value": true,
+                    "IsMaterialised": true
+                  }
+                },
+                "Items": [
+                  {
+                    "Id": "rUFr3GmX",
+                    "Name": "UseCase",
+                    "Schema": {
+                      "SchemaId": "fG9N9vM6",
+                      "SchemaType": "CollectionItem"
+                    },
+                    "Properties": {
+                      "Name": {
+                        "Id": "jzh1Tqtc",
+                        "Name": "Name",
+                        "Schema": {
+                          "SchemaId": "gTRJAA6u",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": "Create",
+                        "IsMaterialised": false
+                      },
+                      "Kind": {
+                        "Id": "pQ8DYD1U",
+                        "Name": "Kind",
+                        "Schema": {
+                          "SchemaId": "24hWYBWf",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": "command",
+                        "IsMaterialised": true
+                      },
+                      "Route": {
+                        "Id": "r1ys6qwS",
+                        "Name": "Route",
+                        "Schema": {
+                          "SchemaId": "znJ67wqj",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": "/",
+                        "IsMaterialised": true
+                      },
+                      "IsAuthenticated": {
+                        "Id": "JqDVwdFD",
+                        "Name": "IsAuthenticated",
+                        "Schema": {
+                          "SchemaId": "x3H8M06Q",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": true,
+                        "IsMaterialised": true
+                      }
+                    },
+                    "IsMaterialised": true,
+                    "ArtifactLinks": [
+                      {
+                        "Id": "AXbz3tfG",
+                        "Tag": "CreateAnAggregate1.ts",
+                        "CommandId": "VUbQMgMU",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/createAnAggregate1/CreateAnAggregate1.ts"
+                      },
+                      {
+                        "Id": "dyT59n1E",
+                        "Tag": "CreateAnAggregate1Controller.ts",
+                        "CommandId": "V3CskeRB",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/createAnAggregate1/CreateAnAggregate1Controller.ts"
+                      },
+                      {
+                        "Id": "24gs0aeV",
+                        "Tag": "CreateAnAggregate1DTO.ts",
+                        "CommandId": "rmWtB8Mg",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/createAnAggregate1/CreateAnAggregate1DTO.ts"
+                      },
+                      {
+                        "Id": "cJQ54QmS",
+                        "Tag": "CreateAnAggregate1Errors.ts",
+                        "CommandId": "5M93B0Sd",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/createAnAggregate1/CreateAnAggregate1Errors.ts"
+                      },
+                      {
+                        "Id": "6V2sjnHj",
+                        "Tag": "index.ts",
+                        "CommandId": "KcSe1axf",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/createAnAggregate1/index.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "Id": "bV2wEDSa",
+                    "Name": "UseCase",
+                    "Schema": {
+                      "SchemaId": "fG9N9vM6",
+                      "SchemaType": "CollectionItem"
+                    },
+                    "Properties": {
+                      "Name": {
+                        "Id": "8PWzBPFJ",
+                        "Name": "Name",
+                        "Schema": {
+                          "SchemaId": "gTRJAA6u",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": "Get",
+                        "IsMaterialised": false
+                      },
+                      "Kind": {
+                        "Id": "W4ShrnVg",
+                        "Name": "Kind",
+                        "Schema": {
+                          "SchemaId": "24hWYBWf",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": "query",
+                        "IsMaterialised": true
+                      },
+                      "Route": {
+                        "Id": "h3SkXXDR",
+                        "Name": "Route",
+                        "Schema": {
+                          "SchemaId": "znJ67wqj",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": "/",
+                        "IsMaterialised": true
+                      },
+                      "IsAuthenticated": {
+                        "Id": "vGwu5ds1",
+                        "Name": "IsAuthenticated",
+                        "Schema": {
+                          "SchemaId": "x3H8M06Q",
+                          "SchemaType": "Attribute"
+                        },
+                        "Value": true,
+                        "IsMaterialised": true
+                      }
+                    },
+                    "IsMaterialised": true,
+                    "ArtifactLinks": [
+                      {
+                        "Id": "9Neq5zbb",
+                        "Tag": "GetAnAggregate1.ts",
+                        "CommandId": "VUbQMgMU",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/getAnAggregate1/GetAnAggregate1.ts"
+                      },
+                      {
+                        "Id": "7NQCHkGJ",
+                        "Tag": "GetAnAggregate1Controller.ts",
+                        "CommandId": "V3CskeRB",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/getAnAggregate1/GetAnAggregate1Controller.ts"
+                      },
+                      {
+                        "Id": "80JgyTt4",
+                        "Tag": "GetAnAggregate1DTO.ts",
+                        "CommandId": "rmWtB8Mg",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/getAnAggregate1/GetAnAggregate1DTO.ts"
+                      },
+                      {
+                        "Id": "qqamP3h3",
+                        "Tag": "GetAnAggregate1Errors.ts",
+                        "CommandId": "5M93B0Sd",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/getAnAggregate1/GetAnAggregate1Errors.ts"
+                      },
+                      {
+                        "Id": "FjfubB29",
+                        "Tag": "index.ts",
+                        "CommandId": "KcSe1axf",
+                        "Path": "src/modules/aDomain/useCases/anAggregate1/getAnAggregate1/index.ts"
+                      }
+                    ]
+                  }
+                ],
+                "IsMaterialised": true
+              }
+            },
+            "IsMaterialised": true,
+            "ArtifactLinks": [
+              {
+                "Id": "Qh9ddEE6",
+                "Tag": "anAggregate1.ts",
+                "CommandId": "Gb3r11qG",
+                "Path": "src/modules/aDomain/domain/anAggregate1.ts"
+              },
+              {
+                "Id": "7YRy9JS0",
+                "Tag": "anAggregate1DTO.ts",
+                "CommandId": "XxMmzS0H",
+                "Path": "src/modules/aDomain/dtos/anAggregate1DTO.ts"
+              },
+              {
+                "Id": "mDRvKwHz",
+                "Tag": "anAggregate1.ts",
+                "CommandId": "x664EbyV",
+                "Path": "src/modules/aDomain/infra/http/routes/anAggregate1.ts"
+              },
+              {
+                "Id": "BTzYWVgx",
+                "Tag": "anAggregate1Map.ts",
+                "CommandId": "eZYU0UWX",
+                "Path": "src/modules/aDomain/mappers/anAggregate1Map.ts"
+              },
+              {
+                "Id": "0H8fxJ6M",
+                "Tag": "anAggregate1Repo.ts",
+                "CommandId": "VsEhhtp3",
+                "Path": "src/modules/aDomain/repos/anAggregate1Repo.ts"
+              },
+              {
+                "Id": "ACxc7ZM3",
+                "Tag": "sequelizeAnAggregate1Repo.ts",
+                "CommandId": "f4m3qHck",
+                "Path": "src/modules/aDomain/repos/implementations/sequelizeAnAggregate1Repo.ts"
+              },
+              {
+                "Id": "dNEJ4DZx",
+                "Tag": "anAggregate1Id.ts",
+                "CommandId": "75jm5Xj0",
+                "Path": "src/modules/aDomain/domain/anAggregate1Id.ts"
+              },
+              {
+                "Id": "86cWFTF8",
+                "Tag": "index.ts",
+                "CommandId": "SaPEKz6h",
+                "Path": "src/modules/aDomain/repos/index.ts"
+              }
+            ]
+          }
+        ],
+        "IsMaterialised": true
+      }
+    },
+    "IsMaterialised": true
+  }
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/1uxps3Sc.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/1uxps3Sc.ts
@@ -1,0 +1,4 @@
+
+export interface {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO {
+  //TODO: properties
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/2CcBpTbV.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/2CcBpTbV.ts
@@ -1,0 +1,63 @@
+
+import { I{{Name | string.pascalsingular}}Repo } from "../{{Name | string.camelsingular}}Repo";
+import { {{Name | string.pascalsingular}}Id } from "../../domain/{{Name | string.camelsingular}}Id";
+import { {{Name | string.pascalsingular}} } from "../../domain/{{Name | string.camelsingular}}";
+import { {{Name | string.pascalsingular}}Map } from "../../mappers/{{Name | string.camelsingular}}Map";
+
+export class {{Name | string.pascalsingular}}Repo implements I{{Name | string.pascalsingular}}Repo {
+
+  private models: any;
+
+  constructor (models: any) {
+    this.models = models;
+  }
+
+  private createBaseQuery (): any {
+    const models = this.models;
+    return {
+      where: {},
+      include: []
+    }
+  }
+
+  public async exists ({{Name | string.camelsingular}}Id: {{Name | string.pascalsingular}}Id): Promise<boolean> {
+    const {{Name | string.pascalsingular}}Model = this.models.{{Name | string.pascalsingular}};
+    const baseQuery = this.createBaseQuery();
+    baseQuery.where['{{Name | string.camelsingular}}_id'] = {{Name | string.camelsingular}}Id.id.toString();
+    const {{Name | string.camelsingular}} = await {{Name | string.pascalsingular}}Model.findOne(baseQuery);
+    const found = !!{{Name | string.camelsingular}} === true;
+    return found;
+  }
+
+  public delete ({{Name | string.camelsingular}}Id: {{Name | string.pascalsingular}}Id): Promise<void> {
+    const {{Name | string.pascalsingular}}Model = this.models.{{Name | string.pascalsingular}};
+    return {{Name | string.pascalsingular}}Model.destroy({ where: { {{Name | string.camelsingular}}_id: {{Name | string.camelsingular}}Id.id.toString() }});
+  }
+
+  public async save ({{Name | string.camelsingular}}: {{Name | string.pascalsingular}}): Promise<void> {
+    const {{Name | string.pascalsingular}}Model = this.models.{{Name | string.pascalsingular}};
+    const exists = await this.exists({{Name | string.camelsingular}}.{{Name | string.camelsingular}}Id);
+    const isNew{{Name | string.pascalsingular}} = !exists;
+    const rawSequelize{{Name | string.pascalsingular}} = await {{Name | string.pascalsingular}}Map.toPersistence({{Name | string.camelsingular}});
+    
+    if (isNew{{Name | string.pascalsingular}}) {
+
+      try {
+        await {{Name | string.pascalsingular}}Model.create(rawSequelize{{Name | string.pascalsingular}});
+        
+      } catch (err) {
+        await this.delete({{Name | string.camelsingular}}.{{Name | string.camelsingular}}Id);
+        throw new Error(err.toString())
+      }
+
+    } else {
+      await {{Name | string.pascalsingular}}Model.update(rawSequelize{{Name | string.pascalsingular}}, { 
+        // To make sure your hooks always run, make sure to include this in
+        // the query
+        individualHooks: true,  
+        hooks: true,
+        where: { {{Name | string.camelsingular}}_id: {{Name | string.camelsingular}}.{{Name | string.camelsingular}}Id.id.toString() }
+      });
+    }
+  }
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/7R1gAwGe.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/7R1gAwGe.ts
@@ -1,0 +1,59 @@
+
+import { AggregateRoot } from "../../../shared/domain/AggregateRoot";
+import { Entity } from "../../../shared/domain/Entity";
+import { UniqueEntityID } from "../../../shared/domain/UniqueEntityID";
+import { Result, Either, left, right } from "../../../shared/core/Result";
+import { Guard, IGuardArgument } from "../../../shared/core/Guard";
+import { {{Name | string.pascalsingular}}Id } from "./{{Name | string.camelsingular}}Id";
+
+export interface {{Name | string.pascalsingular}}Props {
+  //TODO: add domain properties
+}
+
+{{~if (Kind=="aggregate")~}}
+export class {{Name | string.pascalsingular}} extends AggregateRoot<{{Name | string.pascalsingular}}Props> {
+{{~else~}}
+export class {{Name | string.pascalsingular}} extends Entity<{{Name | string.pascalsingular}}Props> {
+{{~end~}}
+
+  get {{Name | string.camelsingular}}Id (): {{Name | string.pascalsingular}}Id {
+    return {{Name | string.pascalsingular}}Id.create(this._id)
+    .getValue();
+  }
+
+  //TODO: add domain properties
+
+  private constructor (props: {{Name | string.pascalsingular}}Props, id?: UniqueEntityID) {
+    super(props, id);
+  }
+
+  public static create (props: {{Name | string.pascalsingular}}Props, id?: UniqueEntityID): Result<{{Name | string.pascalsingular}}> {
+    const guardArgs: IGuardArgument[] = [
+    ];
+
+    //TODO: add arguments to guard
+
+    const guardResult = Guard.againstNullOrUndefinedBulk(guardArgs);
+
+    if (guardResult.isFailure) {
+      return Result.fail<{{Name | string.pascalsingular}}>(guardResult.getErrorValue());
+    }
+
+    const defaultValues: {{Name | string.pascalsingular}}Props = {
+      ...props
+      //TODO: other properties
+    };
+
+    const isNew{{Name | string.pascalsingular}} = !!id === false;
+    const {{Name | string.camelsingular}} = new {{Name | string.pascalsingular}}(defaultValues, id);
+
+    if (isNew{{Name | string.pascalsingular}}) {
+      //TODO: do initializations
+      //TODO: create domain event
+      //{{Name | string.camelsingular}}.addDomainEvent(new {{Name | string.pascalsingular}}Created({{Name | string.camelsingular}}));
+
+    }
+
+    return Result.ok<{{Name | string.pascalsingular}}>({{Name | string.camelsingular}});
+  }
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/Dn8BrSRK.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/Dn8BrSRK.ts
@@ -1,0 +1,15 @@
+
+import { {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}} } from "./{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}";
+import { {{Parent.Name | string.camelsingular}}Repo } from "../../../repos";
+import { {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller } from "./{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller";
+
+const {{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}} = new {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}({{Parent.Name | string.camelsingular}}Repo);
+const {{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}Controller = new {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller(
+  {{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}
+);
+
+export { 
+  {{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}},
+  {{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}Controller
+}
+

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/PmEpX6M7.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/PmEpX6M7.ts
@@ -1,0 +1,43 @@
+import { BaseController } from "../../../../../shared/infra/http/models/BaseController";
+import { DecodedExpressRequest } from "../../../../users/infra/http/models/decodedRequest";
+import { TextUtils } from "../../../../../shared/utils/TextUtils";
+import { {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}} } from "./{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}";
+import { {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO } from "./{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO";
+import { {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Errors } from "./{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Errors";
+
+
+export class {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller extends BaseController {
+  private useCase: {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}};
+
+  constructor (useCase: {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}) {
+    super();
+    this.useCase = useCase;
+  }
+
+  async executeImpl (req: DecodedExpressRequest, res: any): Promise<any> {
+    const { userId } = req.decoded;
+
+    const dto: {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO = {
+      //TODO: populate properties
+    }
+  
+    try {
+      const result = await this.useCase.execute(dto);
+
+      if (result.isLeft()) {
+        const error = result.value;
+  
+        switch (error.constructor) {
+          default:
+            return this.fail(res, error.getErrorValue().message);
+        }
+        
+      } else {
+        return this.ok(res);
+      }
+
+    } catch (err) {
+      return this.fail(res, err)
+    }
+  }
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/VdsjeCF0.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/VdsjeCF0.ts
@@ -1,0 +1,20 @@
+
+import express from 'express';
+import { middleware } from '../../../../../shared/infra/http';
+{{~for usecase in UseCase.Items~}}
+import { {{usecase.Name | string.camelsingular}}{{Name | string.pascalsingular}}Controller } from '../../../useCases/{{Name | string.camelsingular}}/{{usecase.Name | string.camelsingular}}{{Name | string.pascalsingular}}';
+{{~end~}}
+
+const {{Name | string.camelsingular}}Router = express.Router();
+
+{{~for usecase in UseCase.Items~}}
+{{Name | string.camelsingular}}Router.{{if (usecase.Kind=="command")}}post{{else}}get{{end}}('{{usecase.Route}}',
+  {{if (usecase.IsAuthenticated)}}middleware.ensureAuthenticated(),{{end}}
+  (req, res) => {{usecase.Name | string.camelsingular}}{{Name | string.pascalsingular}}Controller.execute(req, res)
+)
+{{~end~}}
+
+export {
+  {{Name | string.camelsingular}}Router
+}
+

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/cTfY562u.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/cTfY562u.ts
@@ -1,0 +1,10 @@
+
+import { {{Name | string.pascalsingular}} } from "../domain/{{Name | string.camelsingular}}";
+import { {{Name | string.pascalsingular}}Id } from "../domain/{{Name | string.camelsingular}}Id";
+
+export interface I{{Name | string.pascalsingular}}Repo {
+  //TODO: add repository methods
+  exists ({{Name | string.camelsingular}}Id: {{Name | string.pascalsingular}}Id): Promise<boolean>;
+  save ({{Name | string.camelsingular}}: {{Name | string.pascalsingular}}): Promise<void>;
+  delete ({{Name | string.camelsingular}}Id: {{Name | string.pascalsingular}}Id): Promise<void>;
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/cd8R6rKQ.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/cd8R6rKQ.ts
@@ -1,0 +1,8 @@
+
+import { UseCaseError } from "../../../../../shared/core/UseCaseError";
+import { Result } from "../../../../../shared/core/Result";
+
+export namespace {{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Errors {
+
+  //TODO: add your errors
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/dwDXxv9G.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/dwDXxv9G.ts
@@ -1,0 +1,51 @@
+
+import { UseCase } from "../../../../../shared/core/UseCase"; 
+import { I{{Parent.Name |string.pascalsingular}}Repo } from "../../../repos/{{Parent.Name |string.camelsingular}}Repo";
+import { Either, Result, left, right } from "../../../../../shared/core/Result";
+import { AppError } from "../../../../../shared/core/AppError";
+import { {{Parent.Name |string.pascalsingular}}, {{Parent.Name |string.pascalsingular}}Props } from "../../../domain/{{Parent.Name |string.camelsingular}}";
+
+import { {{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}}DTO } from "./{{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}}DTO";
+import { {{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}}Errors } from "./{{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}}Errors";
+
+type Response = Either<
+  AppError.UnexpectedError |
+  Result<any>,
+  Result<void>
+>
+
+export class {{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}} implements UseCase<{{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}}DTO, Promise<Response>> {
+  private {{Parent.Name |string.camelsingular}}Repo: I{{Parent.Name |string.pascalsingular}}Repo;
+
+  constructor ({{Parent.Name |string.camelsingular}}Repo: I{{Parent.Name |string.pascalsingular}}Repo) {
+    this.{{Parent.Name |string.camelsingular}}Repo = {{Parent.Name |string.camelsingular}}Repo;
+  }
+  
+  public async execute (request: {{Name | string.pascalsingular}}{{Parent.Name |string.pascalsingular}}DTO): Promise<Response> {
+    let {{Parent.Name |string.camelsingular}}: {{Parent.Name |string.pascalsingular}};
+
+    try {
+
+      //TODO: construct your state
+
+      const {{Parent.Name |string.camelsingular}}Props: {{Parent.Name |string.pascalsingular}}Props = {
+        //TODO: initialize your properties
+      }
+
+      const {{Parent.Name |string.camelsingular}}OrError = {{Parent.Name |string.pascalsingular}}.create({{Parent.Name |string.camelsingular}}Props);
+
+      if ({{Parent.Name |string.camelsingular}}OrError.isFailure) {
+        return left({{Parent.Name |string.camelsingular}}OrError);
+      }
+
+      {{Parent.Name |string.camelsingular}} = {{Parent.Name |string.camelsingular}}OrError.getValue();
+
+      await this.{{Parent.Name |string.camelsingular}}Repo.save({{Parent.Name |string.camelsingular}});
+
+      return right(Result.ok<void>())
+
+    } catch (err) {
+      return left(new AppError.UnexpectedError(err));
+    }
+  }
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/ne5ds8AR.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/ne5ds8AR.ts
@@ -1,0 +1,6 @@
+
+
+export interface {{Name | string.pascalsingular}}DTO {
+  //TODO: add your properties
+}
+

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/r4VRhFkE.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/r4VRhFkE.ts
@@ -1,0 +1,26 @@
+
+import { Mapper } from "../../../shared/infra/Mapper";
+import { {{Name | string.pascalsingular}} } from "../domain/{{Name | string.camelsingular}}";
+import { UniqueEntityID } from "../../../shared/domain/UniqueEntityID";
+
+export class {{Name | string.pascalsingular}}Map implements Mapper<{{Name | string.pascalsingular}}> {
+
+  public static toDomain (raw: any): {{Name | string.pascalsingular}} {
+    
+    const {{Name | string.camelsingular}}OrError = {{Name | string.pascalsingular}}.create({
+      //TODO: map properties to domain
+    }, new UniqueEntityID(raw.{{Name | string.camelsingular}}_id))
+
+    {{Name | string.camelsingular}}OrError.isFailure ? console.log({{Name | string.camelsingular}}OrError.getErrorValue()) : '';
+
+    return {{Name | string.camelsingular}}OrError.isSuccess ? {{Name | string.camelsingular}}OrError.getValue() : null;
+  }
+
+  public static toPersistence ({{Name | string.camelsingular}}: {{Name | string.pascalsingular}}): any {
+    return {
+      //TODO: map properties to persist
+      updatedAt: new Date().toString(),
+      {{Name | string.camelsingular}}_id: {{Name | string.camelsingular}}.{{Name | string.camelsingular}}Id.id.toString(),
+    }
+  }
+}

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/r5vt6KT5.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/r5vt6KT5.ts
@@ -1,0 +1,7 @@
+
+import models from "../../../shared/infra/database/sequelize/models";
+import { {{Name | string.pascalsingular}}Repo } from "./implementations/sequelize{{Name | string.pascalsingular}}Repo";
+
+const {{Name | string.camelsingular}}Repo = new {{Name | string.pascalsingular}}Repo(models);
+
+export { {{Name | string.camelsingular}}Repo };

--- a/automate/patterns/Qps9Xgbd/CodeTemplates/yZY2WRg8.ts
+++ b/automate/patterns/Qps9Xgbd/CodeTemplates/yZY2WRg8.ts
@@ -1,0 +1,19 @@
+
+import { UniqueEntityID } from "../../../shared/domain/UniqueEntityID";
+import { Result } from "../../../shared/core/Result";
+import { Entity } from "../../../shared/domain/Entity";
+
+export class {{Name | string.pascalsingular}}Id extends Entity<any> {
+
+  get id (): UniqueEntityID {
+    return this._id;
+  }
+
+  private constructor (id?: UniqueEntityID) {
+    super(null, id)
+  }
+
+  public static create (id?: UniqueEntityID): Result<{{Name | string.pascalsingular}}Id> {
+    return Result.ok<{{Name | string.pascalsingular}}Id>(new {{Name | string.pascalsingular}}Id(id));
+  }
+}

--- a/automate/patterns/Qps9Xgbd/Pattern.json
+++ b/automate/patterns/Qps9Xgbd/Pattern.json
@@ -1,0 +1,365 @@
+{
+  "Id": "Qps9Xgbd",
+  "Name": "SubDomain",
+  "Attributes": [
+    {
+      "Id": "ppTa0ZPY",
+      "Name": "Name",
+      "DataType": "string",
+      "IsRequired": true,
+      "Choices": []
+    }
+  ],
+  "Elements": [
+    {
+      "Id": "YQY1UP9X",
+      "Name": "Resource",
+      "Attributes": [
+        {
+          "Id": "nYEcsBJ0",
+          "Name": "Name",
+          "DataType": "string",
+          "IsRequired": true,
+          "Choices": []
+        },
+        {
+          "Id": "zyMKwj1w",
+          "Name": "Kind",
+          "DataType": "string",
+          "IsRequired": true,
+          "DefaultValue": "entity",
+          "Choices": [
+            "aggregate",
+            "entity"
+          ]
+        }
+      ],
+      "Elements": [
+        {
+          "Id": "fG9N9vM6",
+          "Name": "UseCase",
+          "Attributes": [
+            {
+              "Id": "gTRJAA6u",
+              "Name": "Name",
+              "DataType": "string",
+              "IsRequired": true,
+              "Choices": []
+            },
+            {
+              "Id": "24hWYBWf",
+              "Name": "Kind",
+              "DataType": "string",
+              "IsRequired": true,
+              "DefaultValue": "command",
+              "Choices": [
+                "command",
+                "query"
+              ]
+            },
+            {
+              "Id": "znJ67wqj",
+              "Name": "Route",
+              "DataType": "string",
+              "IsRequired": true,
+              "DefaultValue": "/",
+              "Choices": []
+            },
+            {
+              "Id": "x3H8M06Q",
+              "Name": "IsAuthenticated",
+              "DataType": "bool",
+              "IsRequired": true,
+              "DefaultValue": "true",
+              "Choices": []
+            }
+          ],
+          "CodeTemplates": [
+            {
+              "Id": "dwDXxv9G",
+              "Name": "UseCase",
+              "LastModifiedUtc": "2022-06-13T08:57:11.8172269Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePost.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "PmEpX6M7",
+              "Name": "Controller",
+              "LastModifiedUtc": "2022-06-13T08:54:14.9353515Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostController.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "1uxps3Sc",
+              "Name": "DTO",
+              "LastModifiedUtc": "2022-06-13T08:50:57.6134271Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostDTO.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "cd8R6rKQ",
+              "Name": "Errors",
+              "LastModifiedUtc": "2022-06-13T08:46:12.6939558Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostErrors.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            },
+            {
+              "Id": "Dn8BrSRK",
+              "Name": "Index",
+              "LastModifiedUtc": "2022-06-13T08:41:16.3553577Z",
+              "Metadata": {
+                "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\index.ts",
+                "OriginalFileExtension": ".ts"
+              }
+            }
+          ],
+          "Automation": [
+            {
+              "Id": "VUbQMgMU",
+              "Name": "UseCaseCommand1",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "dwDXxv9G",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}.ts"
+              }
+            },
+            {
+              "Id": "V3CskeRB",
+              "Name": "ControllerCommand2",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "PmEpX6M7",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller.ts"
+              }
+            },
+            {
+              "Id": "rmWtB8Mg",
+              "Name": "DTOCommand3",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "1uxps3Sc",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO.ts"
+              }
+            },
+            {
+              "Id": "5M93B0Sd",
+              "Name": "ErrorsCommand4",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "cd8R6rKQ",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Errors.ts"
+              }
+            },
+            {
+              "Id": "KcSe1axf",
+              "Name": "IndexCommand5",
+              "Type": "CodeTemplateCommand",
+              "Metadata": {
+                "CodeTemplateId": "Dn8BrSRK",
+                "IsOneOff": true,
+                "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/index.ts"
+              }
+            },
+            {
+              "Id": "8HYpvvQc",
+              "Name": "Go",
+              "Type": "CommandLaunchPoint",
+              "Metadata": {
+                "CommandIds": "VUbQMgMU;V3CskeRB;rmWtB8Mg;5M93B0Sd;KcSe1axf"
+              }
+            }
+          ],
+          "IsCollection": true,
+          "Cardinality": "OneOrMany",
+          "AutoCreate": true
+        }
+      ],
+      "CodeTemplates": [
+        {
+          "Id": "7R1gAwGe",
+          "Name": "Resource",
+          "LastModifiedUtc": "2022-06-13T09:43:10.7913419Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\domain\\post.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "ne5ds8AR",
+          "Name": "DTO",
+          "LastModifiedUtc": "2022-06-12T20:18:16.7838134Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\dtos\\postDTO.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "VdsjeCF0",
+          "Name": "Routes",
+          "LastModifiedUtc": "2022-06-13T09:17:34.8980803Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\infra\\http\\routes\\post.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "r4VRhFkE",
+          "Name": "Mapper",
+          "LastModifiedUtc": "2022-06-13T09:14:55.5337241Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\mappers\\postMap.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "cTfY562u",
+          "Name": "RepoInterface",
+          "LastModifiedUtc": "2022-06-13T08:58:55.9112055Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\postRepo.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "2CcBpTbV",
+          "Name": "RepoImplementation",
+          "LastModifiedUtc": "2022-06-12T20:42:25.5150081Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\implementations\\sequelizePostRepo.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "yZY2WRg8",
+          "Name": "Identifier",
+          "LastModifiedUtc": "2022-06-13T08:29:40.5508653Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\domain\\postId.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        },
+        {
+          "Id": "r5vt6KT5",
+          "Name": "RepoIndex",
+          "LastModifiedUtc": "2022-06-13T09:12:39.2209728Z",
+          "Metadata": {
+            "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\index.ts",
+            "OriginalFileExtension": ".ts"
+          }
+        }
+      ],
+      "Automation": [
+        {
+          "Id": "Gb3r11qG",
+          "Name": "ResourceCommand1",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "7R1gAwGe",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}.ts"
+          }
+        },
+        {
+          "Id": "XxMmzS0H",
+          "Name": "DTOCommand2",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "ne5ds8AR",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/dtos/{{Name | string.camelsingular}}DTO.ts"
+          }
+        },
+        {
+          "Id": "x664EbyV",
+          "Name": "RoutesCommand3",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "VdsjeCF0",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/infra/http/routes/{{Name | string.camelsingular}}.ts"
+          }
+        },
+        {
+          "Id": "eZYU0UWX",
+          "Name": "MapperCommand5",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "r4VRhFkE",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/mappers/{{Name | string.camelsingular}}Map.ts"
+          }
+        },
+        {
+          "Id": "VsEhhtp3",
+          "Name": "RepoInterfaceCommand4",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "cTfY562u",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/{{Name | string.camelsingular}}Repo.ts"
+          }
+        },
+        {
+          "Id": "f4m3qHck",
+          "Name": "RepoImplementationCommand6",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "2CcBpTbV",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/implementations/sequelize{{Name | string.pascalsingular}}Repo.ts"
+          }
+        },
+        {
+          "Id": "75jm5Xj0",
+          "Name": "IdentifierCommand7",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "yZY2WRg8",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}Id.ts"
+          }
+        },
+        {
+          "Id": "SaPEKz6h",
+          "Name": "RepoIndexCommand8",
+          "Type": "CodeTemplateCommand",
+          "Metadata": {
+            "CodeTemplateId": "r5vt6KT5",
+            "IsOneOff": true,
+            "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/index.ts"
+          }
+        }
+      ],
+      "IsCollection": true,
+      "Cardinality": "OneOrMany",
+      "AutoCreate": true
+    }
+  ],
+  "Automation": [
+    {
+      "Id": "5DhrMHhf",
+      "Name": "Go",
+      "Type": "CommandLaunchPoint",
+      "Metadata": {
+        "CommandIds": "Gb3r11qG;XxMmzS0H;x664EbyV;eZYU0UWX;VsEhhtp3;f4m3qHck;75jm5Xj0;SaPEKz6h;VUbQMgMU;V3CskeRB;rmWtB8Mg;5M93B0Sd;KcSe1axf"
+      }
+    }
+  ],
+  "DisplayName": "SubDomain",
+  "ToolkitVersion": {
+    "Current": "0.4.0",
+    "LastChanges": "NoChange"
+  }
+}

--- a/automate/toolkits/Qps9Xgbd/Toolkit.json
+++ b/automate/toolkits/Qps9Xgbd/Toolkit.json
@@ -1,0 +1,424 @@
+{
+  "Id": "Qps9Xgbd",
+  "Version": "0.4.0",
+  "RuntimeVersion": "0.2.3-preview",
+  "Pattern": {
+    "Id": "Qps9Xgbd",
+    "Name": "SubDomain",
+    "Attributes": [
+      {
+        "Id": "ppTa0ZPY",
+        "Name": "Name",
+        "DataType": "string",
+        "IsRequired": true,
+        "Choices": []
+      }
+    ],
+    "Elements": [
+      {
+        "Id": "YQY1UP9X",
+        "Name": "Resource",
+        "Attributes": [
+          {
+            "Id": "nYEcsBJ0",
+            "Name": "Name",
+            "DataType": "string",
+            "IsRequired": true,
+            "Choices": []
+          },
+          {
+            "Id": "zyMKwj1w",
+            "Name": "Kind",
+            "DataType": "string",
+            "IsRequired": true,
+            "DefaultValue": "entity",
+            "Choices": [
+              "aggregate",
+              "entity"
+            ]
+          }
+        ],
+        "Elements": [
+          {
+            "Id": "fG9N9vM6",
+            "Name": "UseCase",
+            "Attributes": [
+              {
+                "Id": "gTRJAA6u",
+                "Name": "Name",
+                "DataType": "string",
+                "IsRequired": true,
+                "Choices": []
+              },
+              {
+                "Id": "24hWYBWf",
+                "Name": "Kind",
+                "DataType": "string",
+                "IsRequired": true,
+                "DefaultValue": "command",
+                "Choices": [
+                  "command",
+                  "query"
+                ]
+              },
+              {
+                "Id": "znJ67wqj",
+                "Name": "Route",
+                "DataType": "string",
+                "IsRequired": true,
+                "DefaultValue": "/",
+                "Choices": []
+              },
+              {
+                "Id": "x3H8M06Q",
+                "Name": "IsAuthenticated",
+                "DataType": "bool",
+                "IsRequired": true,
+                "DefaultValue": "true",
+                "Choices": []
+              }
+            ],
+            "CodeTemplates": [
+              {
+                "Id": "dwDXxv9G",
+                "Name": "UseCase",
+                "LastModifiedUtc": "2022-06-13T08:57:11.8172269Z",
+                "Metadata": {
+                  "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePost.ts",
+                  "OriginalFileExtension": ".ts"
+                }
+              },
+              {
+                "Id": "PmEpX6M7",
+                "Name": "Controller",
+                "LastModifiedUtc": "2022-06-13T08:54:14.9353515Z",
+                "Metadata": {
+                  "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostController.ts",
+                  "OriginalFileExtension": ".ts"
+                }
+              },
+              {
+                "Id": "1uxps3Sc",
+                "Name": "DTO",
+                "LastModifiedUtc": "2022-06-13T08:50:57.6134271Z",
+                "Metadata": {
+                  "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostDTO.ts",
+                  "OriginalFileExtension": ".ts"
+                }
+              },
+              {
+                "Id": "cd8R6rKQ",
+                "Name": "Errors",
+                "LastModifiedUtc": "2022-06-13T08:46:12.6939558Z",
+                "Metadata": {
+                  "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\CreatePostErrors.ts",
+                  "OriginalFileExtension": ".ts"
+                }
+              },
+              {
+                "Id": "Dn8BrSRK",
+                "Name": "Index",
+                "LastModifiedUtc": "2022-06-13T08:41:16.3553577Z",
+                "Metadata": {
+                  "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\useCases\\post\\createPost\\index.ts",
+                  "OriginalFileExtension": ".ts"
+                }
+              }
+            ],
+            "Automation": [
+              {
+                "Id": "VUbQMgMU",
+                "Name": "UseCaseCommand1",
+                "Type": "CodeTemplateCommand",
+                "Metadata": {
+                  "CodeTemplateId": "dwDXxv9G",
+                  "IsOneOff": true,
+                  "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}.ts"
+                }
+              },
+              {
+                "Id": "V3CskeRB",
+                "Name": "ControllerCommand2",
+                "Type": "CodeTemplateCommand",
+                "Metadata": {
+                  "CodeTemplateId": "PmEpX6M7",
+                  "IsOneOff": true,
+                  "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Controller.ts"
+                }
+              },
+              {
+                "Id": "rmWtB8Mg",
+                "Name": "DTOCommand3",
+                "Type": "CodeTemplateCommand",
+                "Metadata": {
+                  "CodeTemplateId": "1uxps3Sc",
+                  "IsOneOff": true,
+                  "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}DTO.ts"
+                }
+              },
+              {
+                "Id": "5M93B0Sd",
+                "Name": "ErrorsCommand4",
+                "Type": "CodeTemplateCommand",
+                "Metadata": {
+                  "CodeTemplateId": "cd8R6rKQ",
+                  "IsOneOff": true,
+                  "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/{{Name | string.pascalsingular}}{{Parent.Name | string.pascalsingular}}Errors.ts"
+                }
+              },
+              {
+                "Id": "KcSe1axf",
+                "Name": "IndexCommand5",
+                "Type": "CodeTemplateCommand",
+                "Metadata": {
+                  "CodeTemplateId": "Dn8BrSRK",
+                  "IsOneOff": true,
+                  "FilePath": "src/modules/{{Parent.Parent.Name | string.camelsingular}}/useCases/{{Parent.Name | string.camelsingular}}/{{Name | string.camelsingular}}{{Parent.Name | string.pascalsingular}}/index.ts"
+                }
+              },
+              {
+                "Id": "8HYpvvQc",
+                "Name": "Go",
+                "Type": "CommandLaunchPoint",
+                "Metadata": {
+                  "CommandIds": "VUbQMgMU;V3CskeRB;rmWtB8Mg;5M93B0Sd;KcSe1axf"
+                }
+              }
+            ],
+            "IsCollection": true,
+            "Cardinality": "OneOrMany",
+            "AutoCreate": true
+          }
+        ],
+        "CodeTemplates": [
+          {
+            "Id": "7R1gAwGe",
+            "Name": "Resource",
+            "LastModifiedUtc": "2022-06-13T09:43:10.7913419Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\domain\\post.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "ne5ds8AR",
+            "Name": "DTO",
+            "LastModifiedUtc": "2022-06-12T20:18:16.7838134Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\dtos\\postDTO.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "VdsjeCF0",
+            "Name": "Routes",
+            "LastModifiedUtc": "2022-06-13T09:17:34.8980803Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\infra\\http\\routes\\post.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "r4VRhFkE",
+            "Name": "Mapper",
+            "LastModifiedUtc": "2022-06-13T09:14:55.5337241Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\mappers\\postMap.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "cTfY562u",
+            "Name": "RepoInterface",
+            "LastModifiedUtc": "2022-06-13T08:58:55.9112055Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\postRepo.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "2CcBpTbV",
+            "Name": "RepoImplementation",
+            "LastModifiedUtc": "2022-06-12T20:42:25.5150081Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\implementations\\sequelizePostRepo.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "yZY2WRg8",
+            "Name": "Identifier",
+            "LastModifiedUtc": "2022-06-13T08:29:40.5508653Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\domain\\postId.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          },
+          {
+            "Id": "r5vt6KT5",
+            "Name": "RepoIndex",
+            "LastModifiedUtc": "2022-06-13T09:12:39.2209728Z",
+            "Metadata": {
+              "OriginalFilePath": "C:\\Projects\\github\\stemmlerjs\\ddd-forum\\src\\modules\\forum\\repos\\index.ts",
+              "OriginalFileExtension": ".ts"
+            }
+          }
+        ],
+        "Automation": [
+          {
+            "Id": "Gb3r11qG",
+            "Name": "ResourceCommand1",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "7R1gAwGe",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}.ts"
+            }
+          },
+          {
+            "Id": "XxMmzS0H",
+            "Name": "DTOCommand2",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "ne5ds8AR",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/dtos/{{Name | string.camelsingular}}DTO.ts"
+            }
+          },
+          {
+            "Id": "x664EbyV",
+            "Name": "RoutesCommand3",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "VdsjeCF0",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/infra/http/routes/{{Name | string.camelsingular}}.ts"
+            }
+          },
+          {
+            "Id": "eZYU0UWX",
+            "Name": "MapperCommand5",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "r4VRhFkE",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/mappers/{{Name | string.camelsingular}}Map.ts"
+            }
+          },
+          {
+            "Id": "VsEhhtp3",
+            "Name": "RepoInterfaceCommand4",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "cTfY562u",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/{{Name | string.camelsingular}}Repo.ts"
+            }
+          },
+          {
+            "Id": "f4m3qHck",
+            "Name": "RepoImplementationCommand6",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "2CcBpTbV",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/implementations/sequelize{{Name | string.pascalsingular}}Repo.ts"
+            }
+          },
+          {
+            "Id": "75jm5Xj0",
+            "Name": "IdentifierCommand7",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "yZY2WRg8",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/domain/{{Name | string.camelsingular}}Id.ts"
+            }
+          },
+          {
+            "Id": "SaPEKz6h",
+            "Name": "RepoIndexCommand8",
+            "Type": "CodeTemplateCommand",
+            "Metadata": {
+              "CodeTemplateId": "r5vt6KT5",
+              "IsOneOff": true,
+              "FilePath": "src/modules/{{Parent.Name | string.camelsingular}}/repos/index.ts"
+            }
+          }
+        ],
+        "IsCollection": true,
+        "Cardinality": "OneOrMany",
+        "AutoCreate": true
+      }
+    ],
+    "Automation": [
+      {
+        "Id": "5DhrMHhf",
+        "Name": "Go",
+        "Type": "CommandLaunchPoint",
+        "Metadata": {
+          "CommandIds": "Gb3r11qG;XxMmzS0H;x664EbyV;eZYU0UWX;VsEhhtp3;f4m3qHck;75jm5Xj0;SaPEKz6h;VUbQMgMU;V3CskeRB;rmWtB8Mg;5M93B0Sd;KcSe1axf"
+        }
+      }
+    ],
+    "DisplayName": "SubDomain",
+    "ToolkitVersion": {
+      "Current": "0.4.0",
+      "LastChanges": "NoChange"
+    }
+  },
+  "CodeTemplateFiles": [
+    {
+      "Id": "7R1gAwGe",
+      "Contents": "DQppbXBvcnQgeyBBZ2dyZWdhdGVSb290IH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2RvbWFpbi9BZ2dyZWdhdGVSb290IjsNCmltcG9ydCB7IEVudGl0eSB9IGZyb20gIi4uLy4uLy4uL3NoYXJlZC9kb21haW4vRW50aXR5IjsNCmltcG9ydCB7IFVuaXF1ZUVudGl0eUlEIH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2RvbWFpbi9VbmlxdWVFbnRpdHlJRCI7DQppbXBvcnQgeyBSZXN1bHQsIEVpdGhlciwgbGVmdCwgcmlnaHQgfSBmcm9tICIuLi8uLi8uLi9zaGFyZWQvY29yZS9SZXN1bHQiOw0KaW1wb3J0IHsgR3VhcmQsIElHdWFyZEFyZ3VtZW50IH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2NvcmUvR3VhcmQiOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCB9IGZyb20gIi4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkIjsNCg0KZXhwb3J0IGludGVyZmFjZSB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVByb3BzIHsNCiAgLy9UT0RPOiBhZGQgZG9tYWluIHByb3BlcnRpZXMNCn0NCg0Ke3t\u002BaWYgKEtpbmQ9PSJhZ2dyZWdhdGUiKX59fQ0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19IGV4dGVuZHMgQWdncmVnYXRlUm9vdDx7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVByb3BzPiB7DQp7e35lbHNlfn19DQpleHBvcnQgY2xhc3Mge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gZXh0ZW5kcyBFbnRpdHk8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Qcm9wcz4gew0Ke3t\u002BZW5kfn19DQoNCiAgZ2V0IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1JZCAoKToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCB7DQogICAgcmV0dXJuIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQuY3JlYXRlKHRoaXMuX2lkKQ0KICAgIC5nZXRWYWx1ZSgpOw0KICB9DQoNCiAgLy9UT0RPOiBhZGQgZG9tYWluIHByb3BlcnRpZXMNCg0KICBwcml2YXRlIGNvbnN0cnVjdG9yIChwcm9wczoge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Qcm9wcywgaWQ/OiBVbmlxdWVFbnRpdHlJRCkgew0KICAgIHN1cGVyKHByb3BzLCBpZCk7DQogIH0NCg0KICBwdWJsaWMgc3RhdGljIGNyZWF0ZSAocHJvcHM6IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UHJvcHMsIGlkPzogVW5pcXVlRW50aXR5SUQpOiBSZXN1bHQ8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0\u002BIHsNCiAgICBjb25zdCBndWFyZEFyZ3M6IElHdWFyZEFyZ3VtZW50W10gPSBbDQogICAgXTsNCg0KICAgIC8vVE9ETzogYWRkIGFyZ3VtZW50cyB0byBndWFyZA0KDQogICAgY29uc3QgZ3VhcmRSZXN1bHQgPSBHdWFyZC5hZ2FpbnN0TnVsbE9yVW5kZWZpbmVkQnVsayhndWFyZEFyZ3MpOw0KDQogICAgaWYgKGd1YXJkUmVzdWx0LmlzRmFpbHVyZSkgew0KICAgICAgcmV0dXJuIFJlc3VsdC5mYWlsPHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19PihndWFyZFJlc3VsdC5nZXRFcnJvclZhbHVlKCkpOw0KICAgIH0NCg0KICAgIGNvbnN0IGRlZmF1bHRWYWx1ZXM6IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UHJvcHMgPSB7DQogICAgICAuLi5wcm9wcw0KICAgICAgLy9UT0RPOiBvdGhlciBwcm9wZXJ0aWVzDQogICAgfTsNCg0KICAgIGNvbnN0IGlzTmV3e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gPSAhIWlkID09PSBmYWxzZTsNCiAgICBjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19ID0gbmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19KGRlZmF1bHRWYWx1ZXMsIGlkKTsNCg0KICAgIGlmIChpc05ld3t7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19KSB7DQogICAgICAvL1RPRE86IGRvIGluaXRpYWxpemF0aW9ucw0KICAgICAgLy9UT0RPOiBjcmVhdGUgZG9tYWluIGV2ZW50DQogICAgICAvL3t7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0uYWRkRG9tYWluRXZlbnQobmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q3JlYXRlZCh7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19KSk7DQoNCiAgICB9DQoNCiAgICByZXR1cm4gUmVzdWx0Lm9rPHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Pih7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19KTsNCiAgfQ0KfQ=="
+    },
+    {
+      "Id": "ne5ds8AR",
+      "Contents": "DQoNCmV4cG9ydCBpbnRlcmZhY2Uge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1EVE8gew0KICAvL1RPRE86IGFkZCB5b3VyIHByb3BlcnRpZXMNCn0NCg0K"
+    },
+    {
+      "Id": "VdsjeCF0",
+      "Contents": "DQppbXBvcnQgZXhwcmVzcyBmcm9tICdleHByZXNzJzsNCmltcG9ydCB7IG1pZGRsZXdhcmUgfSBmcm9tICcuLi8uLi8uLi8uLi8uLi9zaGFyZWQvaW5mcmEvaHR0cCc7DQp7e35mb3IgdXNlY2FzZSBpbiBVc2VDYXNlLkl0ZW1zfn19DQppbXBvcnQgeyB7e3VzZWNhc2UuTmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX17e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUNvbnRyb2xsZXIgfSBmcm9tICcuLi8uLi8uLi91c2VDYXNlcy97e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19L3t7dXNlY2FzZS5OYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19JzsNCnt7fmVuZH59fQ0KDQpjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19Um91dGVyID0gZXhwcmVzcy5Sb3V0ZXIoKTsNCg0Ke3t\u002BZm9yIHVzZWNhc2UgaW4gVXNlQ2FzZS5JdGVtc359fQ0Ke3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJvdXRlci57e2lmICh1c2VjYXNlLktpbmQ9PSJjb21tYW5kIil9fXBvc3R7e2Vsc2V9fWdldHt7ZW5kfX0oJ3t7dXNlY2FzZS5Sb3V0ZX19JywNCiAge3tpZiAodXNlY2FzZS5Jc0F1dGhlbnRpY2F0ZWQpfX1taWRkbGV3YXJlLmVuc3VyZUF1dGhlbnRpY2F0ZWQoKSx7e2VuZH19DQogIChyZXEsIHJlcykgPT4ge3t1c2VjYXNlLk5hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Db250cm9sbGVyLmV4ZWN1dGUocmVxLCByZXMpDQopDQp7e35lbmR\u002BfX0NCg0KZXhwb3J0IHsNCiAge3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJvdXRlcg0KfQ0KDQo="
+    },
+    {
+      "Id": "r4VRhFkE",
+      "Contents": "DQppbXBvcnQgeyBNYXBwZXIgfSBmcm9tICIuLi8uLi8uLi9zaGFyZWQvaW5mcmEvTWFwcGVyIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19IH0gZnJvbSAiLi4vZG9tYWluL3t7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0iOw0KaW1wb3J0IHsgVW5pcXVlRW50aXR5SUQgfSBmcm9tICIuLi8uLi8uLi9zaGFyZWQvZG9tYWluL1VuaXF1ZUVudGl0eUlEIjsNCg0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19TWFwIGltcGxlbWVudHMgTWFwcGVyPHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19PiB7DQoNCiAgcHVibGljIHN0YXRpYyB0b0RvbWFpbiAocmF3OiBhbnkpOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB7DQogICAgDQogICAgY29uc3Qge3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IgPSB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fS5jcmVhdGUoew0KICAgICAgLy9UT0RPOiBtYXAgcHJvcGVydGllcyB0byBkb21haW4NCiAgICB9LCBuZXcgVW5pcXVlRW50aXR5SUQocmF3Lnt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1faWQpKQ0KDQogICAge3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IuaXNGYWlsdXJlID8gY29uc29sZS5sb2coe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IuZ2V0RXJyb3JWYWx1ZSgpKSA6ICcnOw0KDQogICAgcmV0dXJuIHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1PckVycm9yLmlzU3VjY2VzcyA/IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1PckVycm9yLmdldFZhbHVlKCkgOiBudWxsOw0KICB9DQoNCiAgcHVibGljIHN0YXRpYyB0b1BlcnNpc3RlbmNlICh7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19OiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSk6IGFueSB7DQogICAgcmV0dXJuIHsNCiAgICAgIC8vVE9ETzogbWFwIHByb3BlcnRpZXMgdG8gcGVyc2lzdA0KICAgICAgdXBkYXRlZEF0OiBuZXcgRGF0ZSgpLnRvU3RyaW5nKCksDQogICAgICB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19X2lkOiB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19Lnt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1JZC5pZC50b1N0cmluZygpLA0KICAgIH0NCiAgfQ0KfQ=="
+    },
+    {
+      "Id": "cTfY562u",
+      "Contents": "DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB9IGZyb20gIi4uL2RvbWFpbi97e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19IjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQgfSBmcm9tICIuLi9kb21haW4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkIjsNCg0KZXhwb3J0IGludGVyZmFjZSBJe3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvIHsNCiAgLy9UT0RPOiBhZGQgcmVwb3NpdG9yeSBtZXRob2RzDQogIGV4aXN0cyAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUlkKTogUHJvbWlzZTxib29sZWFuPjsNCiAgc2F2ZSAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0pOiBQcm9taXNlPHZvaWQ\u002BOw0KICBkZWxldGUgKHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1JZDoge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCk6IFByb21pc2U8dm9pZD47DQp9"
+    },
+    {
+      "Id": "2CcBpTbV",
+      "Contents": "DQppbXBvcnQgeyBJe3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvIH0gZnJvbSAiLi4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJlcG8iOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZCB9IGZyb20gIi4uLy4uL2RvbWFpbi97e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQiOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gfSBmcm9tICIuLi8uLi9kb21haW4ve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fSI7DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1hcCB9IGZyb20gIi4uLy4uL21hcHBlcnMve3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU1hcCI7DQoNCmV4cG9ydCBjbGFzcyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVJlcG8gaW1wbGVtZW50cyBJe3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvIHsNCg0KICBwcml2YXRlIG1vZGVsczogYW55Ow0KDQogIGNvbnN0cnVjdG9yIChtb2RlbHM6IGFueSkgew0KICAgIHRoaXMubW9kZWxzID0gbW9kZWxzOw0KICB9DQoNCiAgcHJpdmF0ZSBjcmVhdGVCYXNlUXVlcnkgKCk6IGFueSB7DQogICAgY29uc3QgbW9kZWxzID0gdGhpcy5tb2RlbHM7DQogICAgcmV0dXJuIHsNCiAgICAgIHdoZXJlOiB7fSwNCiAgICAgIGluY2x1ZGU6IFtdDQogICAgfQ0KICB9DQoNCiAgcHVibGljIGFzeW5jIGV4aXN0cyAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUlkKTogUHJvbWlzZTxib29sZWFuPiB7DQogICAgY29uc3Qge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Nb2RlbCA9IHRoaXMubW9kZWxzLnt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Ow0KICAgIGNvbnN0IGJhc2VRdWVyeSA9IHRoaXMuY3JlYXRlQmFzZVF1ZXJ5KCk7DQogICAgYmFzZVF1ZXJ5LndoZXJlWyd7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19X2lkJ10gPSB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQuaWQudG9TdHJpbmcoKTsNCiAgICBjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19ID0gYXdhaXQge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Nb2RlbC5maW5kT25lKGJhc2VRdWVyeSk7DQogICAgY29uc3QgZm91bmQgPSAhIXt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0gPT09IHRydWU7DQogICAgcmV0dXJuIGZvdW5kOw0KICB9DQoNCiAgcHVibGljIGRlbGV0ZSAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUlkKTogUHJvbWlzZTx2b2lkPiB7DQogICAgY29uc3Qge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Nb2RlbCA9IHRoaXMubW9kZWxzLnt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Ow0KICAgIHJldHVybiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1vZGVsLmRlc3Ryb3koeyB3aGVyZTogeyB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19X2lkOiB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQuaWQudG9TdHJpbmcoKSB9fSk7DQogIH0NCg0KICBwdWJsaWMgYXN5bmMgc2F2ZSAoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0pOiBQcm9taXNlPHZvaWQ\u002BIHsNCiAgICBjb25zdCB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1vZGVsID0gdGhpcy5tb2RlbHMue3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX07DQogICAgY29uc3QgZXhpc3RzID0gYXdhaXQgdGhpcy5leGlzdHMoe3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fS57e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19SWQpOw0KICAgIGNvbnN0IGlzTmV3e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0gPSAhZXhpc3RzOw0KICAgIGNvbnN0IHJhd1NlcXVlbGl6ZXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19ID0gYXdhaXQge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1NYXAudG9QZXJzaXN0ZW5jZSh7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19KTsNCiAgICANCiAgICBpZiAoaXNOZXd7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSkgew0KDQogICAgICB0cnkgew0KICAgICAgICBhd2FpdCB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fU1vZGVsLmNyZWF0ZShyYXdTZXF1ZWxpemV7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSk7DQogICAgICAgIA0KICAgICAgfSBjYXRjaCAoZXJyKSB7DQogICAgICAgIGF3YWl0IHRoaXMuZGVsZXRlKHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0ue3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkKTsNCiAgICAgICAgdGhyb3cgbmV3IEVycm9yKGVyci50b1N0cmluZygpKQ0KICAgICAgfQ0KDQogICAgfSBlbHNlIHsNCiAgICAgIGF3YWl0IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19TW9kZWwudXBkYXRlKHJhd1NlcXVlbGl6ZXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19LCB7IA0KICAgICAgICAvLyBUbyBtYWtlIHN1cmUgeW91ciBob29rcyBhbHdheXMgcnVuLCBtYWtlIHN1cmUgdG8gaW5jbHVkZSB0aGlzIGluDQogICAgICAgIC8vIHRoZSBxdWVyeQ0KICAgICAgICBpbmRpdmlkdWFsSG9va3M6IHRydWUsICANCiAgICAgICAgaG9va3M6IHRydWUsDQogICAgICAgIHdoZXJlOiB7IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1faWQ6IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX0ue3tOYW1lIHwgc3RyaW5nLmNhbWVsc2luZ3VsYXJ9fUlkLmlkLnRvU3RyaW5nKCkgfQ0KICAgICAgfSk7DQogICAgfQ0KICB9DQp9"
+    },
+    {
+      "Id": "yZY2WRg8",
+      "Contents": "DQppbXBvcnQgeyBVbmlxdWVFbnRpdHlJRCB9IGZyb20gIi4uLy4uLy4uL3NoYXJlZC9kb21haW4vVW5pcXVlRW50aXR5SUQiOw0KaW1wb3J0IHsgUmVzdWx0IH0gZnJvbSAiLi4vLi4vLi4vc2hhcmVkL2NvcmUvUmVzdWx0IjsNCmltcG9ydCB7IEVudGl0eSB9IGZyb20gIi4uLy4uLy4uL3NoYXJlZC9kb21haW4vRW50aXR5IjsNCg0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQgZXh0ZW5kcyBFbnRpdHk8YW55PiB7DQoNCiAgZ2V0IGlkICgpOiBVbmlxdWVFbnRpdHlJRCB7DQogICAgcmV0dXJuIHRoaXMuX2lkOw0KICB9DQoNCiAgcHJpdmF0ZSBjb25zdHJ1Y3RvciAoaWQ/OiBVbmlxdWVFbnRpdHlJRCkgew0KICAgIHN1cGVyKG51bGwsIGlkKQ0KICB9DQoNCiAgcHVibGljIHN0YXRpYyBjcmVhdGUgKGlkPzogVW5pcXVlRW50aXR5SUQpOiBSZXN1bHQ8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZD4gew0KICAgIHJldHVybiBSZXN1bHQub2s8e3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1JZD4obmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19SWQoaWQpKTsNCiAgfQ0KfQ=="
+    },
+    {
+      "Id": "r5vt6KT5",
+      "Contents": "DQppbXBvcnQgbW9kZWxzIGZyb20gIi4uLy4uLy4uL3NoYXJlZC9pbmZyYS9kYXRhYmFzZS9zZXF1ZWxpemUvbW9kZWxzIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyB9IGZyb20gIi4vaW1wbGVtZW50YXRpb25zL3NlcXVlbGl6ZXt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyI7DQoNCmNvbnN0IHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvID0gbmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyhtb2RlbHMpOw0KDQpleHBvcnQgeyB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbyB9Ow0K"
+    },
+    {
+      "Id": "dwDXxv9G",
+      "Contents": "DQppbXBvcnQgeyBVc2VDYXNlIH0gZnJvbSAiLi4vLi4vLi4vLi4vLi4vc2hhcmVkL2NvcmUvVXNlQ2FzZSI7IA0KaW1wb3J0IHsgSXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbyB9IGZyb20gIi4uLy4uLy4uL3JlcG9zL3t7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvIjsNCmltcG9ydCB7IEVpdGhlciwgUmVzdWx0LCBsZWZ0LCByaWdodCB9IGZyb20gIi4uLy4uLy4uLy4uLy4uL3NoYXJlZC9jb3JlL1Jlc3VsdCI7DQppbXBvcnQgeyBBcHBFcnJvciB9IGZyb20gIi4uLy4uLy4uLy4uLy4uL3NoYXJlZC9jb3JlL0FwcEVycm9yIjsNCmltcG9ydCB7IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19LCB7e1BhcmVudC5OYW1lIHxzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fVByb3BzIH0gZnJvbSAiLi4vLi4vLi4vZG9tYWluL3t7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX0iOw0KDQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIH0gZnJvbSAiLi97e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1FcnJvcnMgfSBmcm9tICIuL3t7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1FcnJvcnMiOw0KDQp0eXBlIFJlc3BvbnNlID0gRWl0aGVyPA0KICBBcHBFcnJvci5VbmV4cGVjdGVkRXJyb3IgfA0KICBSZXN1bHQ8YW55PiwNCiAgUmVzdWx0PHZvaWQ\u002BDQo\u002BDQoNCmV4cG9ydCBjbGFzcyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19IGltcGxlbWVudHMgVXNlQ2FzZTx7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPLCBQcm9taXNlPFJlc3BvbnNlPj4gew0KICBwcml2YXRlIHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvOiBJe3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1SZXBvOw0KDQogIGNvbnN0cnVjdG9yICh7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbzogSXt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UmVwbykgew0KICAgIHRoaXMue3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVJlcG8gPSB7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbzsNCiAgfQ0KICANCiAgcHVibGljIGFzeW5jIGV4ZWN1dGUgKHJlcXVlc3Q6IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8c3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1EVE8pOiBQcm9taXNlPFJlc3BvbnNlPiB7DQogICAgbGV0IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX06IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Ow0KDQogICAgdHJ5IHsNCg0KICAgICAgLy9UT0RPOiBjb25zdHJ1Y3QgeW91ciBzdGF0ZQ0KDQogICAgICBjb25zdCB7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19UHJvcHM6IHt7UGFyZW50Lk5hbWUgfHN0cmluZy5wYXNjYWxzaW5ndWxhcn19UHJvcHMgPSB7DQogICAgICAgIC8vVE9ETzogaW5pdGlhbGl6ZSB5b3VyIHByb3BlcnRpZXMNCiAgICAgIH0NCg0KICAgICAgY29uc3Qge3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fU9yRXJyb3IgPSB7e1BhcmVudC5OYW1lIHxzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fS5jcmVhdGUoe3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fVByb3BzKTsNCg0KICAgICAgaWYgKHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1PckVycm9yLmlzRmFpbHVyZSkgew0KICAgICAgICByZXR1cm4gbGVmdCh7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19T3JFcnJvcik7DQogICAgICB9DQoNCiAgICAgIHt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX0gPSB7e1BhcmVudC5OYW1lIHxzdHJpbmcuY2FtZWxzaW5ndWxhcn19T3JFcnJvci5nZXRWYWx1ZSgpOw0KDQogICAgICBhd2FpdCB0aGlzLnt7UGFyZW50Lk5hbWUgfHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvLnNhdmUoe3tQYXJlbnQuTmFtZSB8c3RyaW5nLmNhbWVsc2luZ3VsYXJ9fSk7DQoNCiAgICAgIHJldHVybiByaWdodChSZXN1bHQub2s8dm9pZD4oKSkNCg0KICAgIH0gY2F0Y2ggKGVycikgew0KICAgICAgcmV0dXJuIGxlZnQobmV3IEFwcEVycm9yLlVuZXhwZWN0ZWRFcnJvcihlcnIpKTsNCiAgICB9DQogIH0NCn0="
+    },
+    {
+      "Id": "PmEpX6M7",
+      "Contents": "aW1wb3J0IHsgQmFzZUNvbnRyb2xsZXIgfSBmcm9tICIuLi8uLi8uLi8uLi8uLi9zaGFyZWQvaW5mcmEvaHR0cC9tb2RlbHMvQmFzZUNvbnRyb2xsZXIiOw0KaW1wb3J0IHsgRGVjb2RlZEV4cHJlc3NSZXF1ZXN0IH0gZnJvbSAiLi4vLi4vLi4vLi4vdXNlcnMvaW5mcmEvaHR0cC9tb2RlbHMvZGVjb2RlZFJlcXVlc3QiOw0KaW1wb3J0IHsgVGV4dFV0aWxzIH0gZnJvbSAiLi4vLi4vLi4vLi4vLi4vc2hhcmVkL3V0aWxzL1RleHRVdGlscyI7DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB9IGZyb20gIi4ve3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0iOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1EVE8gfSBmcm9tICIuL3t7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIjsNCmltcG9ydCB7IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RXJyb3JzIH0gZnJvbSAiLi97e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUVycm9ycyI7DQoNCg0KZXhwb3J0IGNsYXNzIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q29udHJvbGxlciBleHRlbmRzIEJhc2VDb250cm9sbGVyIHsNCiAgcHJpdmF0ZSB1c2VDYXNlOiB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fTsNCg0KICBjb25zdHJ1Y3RvciAodXNlQ2FzZToge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0pIHsNCiAgICBzdXBlcigpOw0KICAgIHRoaXMudXNlQ2FzZSA9IHVzZUNhc2U7DQogIH0NCg0KICBhc3luYyBleGVjdXRlSW1wbCAocmVxOiBEZWNvZGVkRXhwcmVzc1JlcXVlc3QsIHJlczogYW55KTogUHJvbWlzZTxhbnk\u002BIHsNCiAgICBjb25zdCB7IHVzZXJJZCB9ID0gcmVxLmRlY29kZWQ7DQoNCiAgICBjb25zdCBkdG86IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPID0gew0KICAgICAgLy9UT0RPOiBwb3B1bGF0ZSBwcm9wZXJ0aWVzDQogICAgfQ0KICANCiAgICB0cnkgew0KICAgICAgY29uc3QgcmVzdWx0ID0gYXdhaXQgdGhpcy51c2VDYXNlLmV4ZWN1dGUoZHRvKTsNCg0KICAgICAgaWYgKHJlc3VsdC5pc0xlZnQoKSkgew0KICAgICAgICBjb25zdCBlcnJvciA9IHJlc3VsdC52YWx1ZTsNCiAgDQogICAgICAgIHN3aXRjaCAoZXJyb3IuY29uc3RydWN0b3IpIHsNCiAgICAgICAgICBkZWZhdWx0Og0KICAgICAgICAgICAgcmV0dXJuIHRoaXMuZmFpbChyZXMsIGVycm9yLmdldEVycm9yVmFsdWUoKS5tZXNzYWdlKTsNCiAgICAgICAgfQ0KICAgICAgICANCiAgICAgIH0gZWxzZSB7DQogICAgICAgIHJldHVybiB0aGlzLm9rKHJlcyk7DQogICAgICB9DQoNCiAgICB9IGNhdGNoIChlcnIpIHsNCiAgICAgIHJldHVybiB0aGlzLmZhaWwocmVzLCBlcnIpDQogICAgfQ0KICB9DQp9"
+    },
+    {
+      "Id": "1uxps3Sc",
+      "Contents": "DQpleHBvcnQgaW50ZXJmYWNlIHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19RFRPIHsNCiAgLy9UT0RPOiBwcm9wZXJ0aWVzDQp9"
+    },
+    {
+      "Id": "cd8R6rKQ",
+      "Contents": "DQppbXBvcnQgeyBVc2VDYXNlRXJyb3IgfSBmcm9tICIuLi8uLi8uLi8uLi8uLi9zaGFyZWQvY29yZS9Vc2VDYXNlRXJyb3IiOw0KaW1wb3J0IHsgUmVzdWx0IH0gZnJvbSAiLi4vLi4vLi4vLi4vLi4vc2hhcmVkL2NvcmUvUmVzdWx0IjsNCg0KZXhwb3J0IG5hbWVzcGFjZSB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUVycm9ycyB7DQoNCiAgLy9UT0RPOiBhZGQgeW91ciBlcnJvcnMNCn0="
+    },
+    {
+      "Id": "Dn8BrSRK",
+      "Contents": "DQppbXBvcnQgeyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fSB9IGZyb20gIi4ve3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0iOw0KaW1wb3J0IHsge3tQYXJlbnQuTmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX1SZXBvIH0gZnJvbSAiLi4vLi4vLi4vcmVwb3MiOw0KaW1wb3J0IHsge3tOYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX1Db250cm9sbGVyIH0gZnJvbSAiLi97e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUNvbnRyb2xsZXIiOw0KDQpjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19ID0gbmV3IHt7TmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19KHt7UGFyZW50Lk5hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19UmVwbyk7DQpjb25zdCB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q29udHJvbGxlciA9IG5ldyB7e05hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fXt7UGFyZW50Lk5hbWUgfCBzdHJpbmcucGFzY2Fsc2luZ3VsYXJ9fUNvbnRyb2xsZXIoDQogIHt7TmFtZSB8IHN0cmluZy5jYW1lbHNpbmd1bGFyfX17e1BhcmVudC5OYW1lIHwgc3RyaW5nLnBhc2NhbHNpbmd1bGFyfX0NCik7DQoNCmV4cG9ydCB7IA0KICB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19LA0KICB7e05hbWUgfCBzdHJpbmcuY2FtZWxzaW5ndWxhcn19e3tQYXJlbnQuTmFtZSB8IHN0cmluZy5wYXNjYWxzaW5ndWxhcn19Q29udHJvbGxlcg0KfQ0KDQo="
+    }
+  ]
+}


### PR DESCRIPTION
Added a first version of an [automate](https://github.com/jezzsantos/automate) toolkit to create new sub-domains, and usecases. 

Please see the included README.md (in this PR) for how it was designed and built.